### PR TITLE
Add possibility to override IEDriverServer architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,16 @@ server.stdout.on('data', function(output) {
 });
 ```
 
+## IEDriverServer architecture
+
+IEDriverServer 32/64bit version is downloaded according to processor architecture. There are [known issues with sendkeys](https://code.google.com/p/selenium/issues/detail?id=5116) being slow on 64bit version of Internet Explorer. To address this issue, IEDriverServer architecture can be configured using IEDRIVER_ARCH environment variable. Supported values are `ia32` and `x64`.
+
+### Example: Force 32bit IEDriverServer to be used
+
+```shell
+set IEDRIVER_ARCH=ia32
+npm install selenium-standalone@latest -g
+start-selenium
+```
+
 `selenium-standalone` versions maps `selenium` versions.

--- a/conf.js
+++ b/conf.js
@@ -16,6 +16,7 @@ module.exports = {
   ieDr: {
     path: path.join(__dirname, '.selenium', version, 'IEDriverServer.exe'),
     // see http://selenium-release.storage.googleapis.com/index.html
-    v: '2.43.0'
+    v: '2.43.0',
+    arch: process.env.IEDRIVER_ARCH !== undefined ? process.env.IEDRIVER_ARCH : process.arch
   }
 };

--- a/install.js
+++ b/install.js
@@ -176,9 +176,9 @@ function getChromeDriverPlatform() {
 }
 
 function getIeDriverPlatform() {
-  if (process.arch === 'ia32') {
+  if (conf.ieDr.arch === 'ia32') {
     return 'Win32';
-  } else if (process.arch === 'x64') {
+  } else if (conf.ieDr.arch === 'x64') {
     return 'x64';
   } else {
     return new Error('Architecture not supported');


### PR DESCRIPTION
Added IEDRIVER_ARCH environment variable for overriding the processor architecture type based IEDriverServer selection.
