### PR TITLE
ctrl-c loses default behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,16 +38,15 @@ function standalone(spawnOptions, seleniumArgs) {
   return selenium;
 }
 
+// Kill child processes when exit event is called.
 function kill() {
   var process;
   while (process = processes.shift()) {
     process.kill('SIGTERM');
   }
 }
+process.on('exit', kill);
 
-['exit', 'SIGTERM', 'SIGINT'].forEach(function listenAndKill(evName) {
-  process.on(evName, kill);
-});
 
 // backward compat with original programmatic PR
 // https://github.com/vvo/selenium-standalone/pull/4


### PR DESCRIPTION
The index.js file was overriding the SIGINT event. This was not allowing us to kill the parent process because overriding the SIGINT event removes the default handler (http://nodejs.org/docs/latest/api/process.html#process_signal_events).

The process still listens for the 'exit' event, which gets signaled when calling SIGINT as well. Using that instead to kill child process.
