### PR TITLE
Return the child process at the outset

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -54,4 +54,6 @@ function start(opts, cb) {
 
     cb(null, selenium);
   });
+  
+  return selenium;
 }


### PR DESCRIPTION
Gives us the ability to monitor (and log) output to aid debugging when something went wrong (the callback is too late for a lot of the good stuff).