### PR TITLE
Adding support for parsing -hub argument and using accompanying hostname...

### DIFF
--- a/lib/check-started.js
+++ b/lib/check-started.js
@@ -1,7 +1,7 @@
 module.exports = checkStarted;
 
 var request = require('request').defaults({json: true});
-var URI = require('URIjs');
+var getSeleniumHub = require('./get-selenium-hub.js');
 
 function checkStarted(seleniumArgs, cb) {
   var retries = 0;
@@ -31,23 +31,4 @@ function checkStarted(seleniumArgs, cb) {
   }
 
   hasStarted();
-}
-
-function getSeleniumHub(seleniumArgs) {
-  var port = 4444;
-  var hostname = 'localhost';
-  var portArg = seleniumArgs.indexOf('-port');
-  var hubArg = seleniumArgs.indexOf('-hub');
-
-  if (hubArg !== -1) {
-    hubURI = new URI(seleniumArgs[hubArg + 1]);
-    hostname = hubURI.hostname();
-    port = hubURI.port();
-  }
-
-  if (portArg !== -1) {
-    port = seleniumArgs[portArg + 1];
-  }
-
-  return 'http://' + hostname + ':' + port + '/wd/hub/status';
 }

--- a/lib/check-started.js
+++ b/lib/check-started.js
@@ -1,6 +1,7 @@
 module.exports = checkStarted;
 
 var request = require('request').defaults({json: true});
+var URI = require('URIjs');
 
 function checkStarted(seleniumArgs, cb) {
   var retries = 0;
@@ -33,15 +34,20 @@ function checkStarted(seleniumArgs, cb) {
 }
 
 function getSeleniumHub(seleniumArgs) {
-  var defaultPort = 4444;
+  var port = 4444;
+  var hostname = 'localhost';
   var portArg = seleniumArgs.indexOf('-port');
-  var port;
+  var hubArg = seleniumArgs.indexOf('-hub');
 
-  if (portArg === -1) {
-    port = defaultPort;
-  } else {
+  if (hubArg !== -1) {
+    hubURI = new URI(seleniumArgs[hubArg + 1]);
+    hostname = hubURI.hostname();
+    port = hubURI.port();
+  }
+
+  if (portArg !== -1) {
     port = seleniumArgs[portArg + 1];
   }
 
-  return 'http://localhost:' + port + '/wd/hub/status';
+  return 'http://' + hostname + ':' + port + '/wd/hub/status';
 }

--- a/lib/get-selenium-hub.js
+++ b/lib/get-selenium-hub.js
@@ -1,0 +1,22 @@
+module.exports = getSeleniumHub;
+
+var URI = require('URIjs');
+
+function getSeleniumHub(seleniumArgs) {
+  var port = 4444;
+  var hostname = 'localhost';
+  var portArg = seleniumArgs.indexOf('-port');
+  var hubArg = seleniumArgs.indexOf('-hub');
+
+  if (hubArg !== -1) {
+    hubURI = new URI(seleniumArgs[hubArg + 1]);
+    hostname = hubURI.hostname() || hostname;
+    port = hubURI.port() || port;
+  }
+
+  if (portArg !== -1) {
+    port = seleniumArgs[portArg + 1];
+  }
+
+  return 'http://' + hostname + ':' + port + '/wd/hub/status';
+}

--- a/lib/start.js
+++ b/lib/start.js
@@ -68,21 +68,24 @@ function start(opts, cb) {
 
     opts.spawnCb(selenium);
 
-    selenium.on('exit', errorIfNeverStarted);
+    if (opts.seleniumArgs.indexOf('node') === -1) {
 
-    checkStarted(args, function started(err) {
-      selenium.removeListener('exit', errorIfNeverStarted);
+      selenium.on('exit', errorIfNeverStarted);
 
-      if (err) {
-        cb(err);
-        return;
+      checkStarted(args, function started(err) {
+        selenium.removeListener('exit', errorIfNeverStarted);
+
+        if (err) {
+          cb(err);
+          return;
+        }
+
+        cb(null, selenium);
+      });
+
+      function errorIfNeverStarted() {
+        cb(new Error('Selenium exited before it could start'));
       }
-
-      cb(null, selenium);
-    });
-
-    function errorIfNeverStarted() {
-      cb(new Error('Selenium exited before it could start'));
     }
   });
 }

--- a/lib/start.js
+++ b/lib/start.js
@@ -68,24 +68,21 @@ function start(opts, cb) {
 
     opts.spawnCb(selenium);
 
-    if (opts.seleniumArgs.indexOf('node') === -1) {
+    selenium.on('exit', errorIfNeverStarted);
 
-      selenium.on('exit', errorIfNeverStarted);
+    checkStarted(args, function started(err) {
+      selenium.removeListener('exit', errorIfNeverStarted);
 
-      checkStarted(args, function started(err) {
-        selenium.removeListener('exit', errorIfNeverStarted);
-
-        if (err) {
-          cb(err);
-          return;
-        }
-
-        cb(null, selenium);
-      });
-
-      function errorIfNeverStarted() {
-        cb(new Error('Selenium exited before it could start'));
+      if (err) {
+        cb(err);
+        return;
       }
+
+      cb(null, selenium);
+    });
+
+    function errorIfNeverStarted() {
+      cb(new Error('Selenium exited before it could start'));
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "progress": "^1.1.8",
     "request": "^2.51.0",
     "unzip": "^0.1.11",
+    "URIjs": "^1.15.0",
     "whereis": "^0.4.0"
   },
   "devDependencies": {

--- a/test/get-selenium-hub-test.js
+++ b/test/get-selenium-hub-test.js
@@ -1,0 +1,21 @@
+var assert = require("assert")
+var getSeleniumHub = require('../lib/get-selenium-hub');
+
+describe('getSeleniumHub', function () {
+  var data = [{args: [], expected: 'http://localhost:4444/wd/hub/status'},
+              {args: ['-port', '5555'], expected: 'http://localhost:5555/wd/hub/status'},
+              {args: ['-hub', 'http://foo/wd/register'], expected: 'http://foo:4444/wd/hub/status'},
+              {args: ['-hub', 'http://foo:6666/wd/register'], expected: 'http://foo:6666/wd/hub/status'},
+              {args: ['-hub', 'http://foo/wd/register', '-port', '7777'], expected: 'http://foo:7777/wd/hub/status'},
+              {args: ['-hub', 'http://foo:6666/wd/register', '-port', '7777'], expected: 'http://foo:7777/wd/hub/status'}];
+
+  var testWithData = function (dataItem) {
+    return function () {
+      assert.equal(getSeleniumHub(dataItem.args), dataItem.expected);
+    };
+  };
+
+  data.forEach(function (dataItem) {
+    it("getSeleniumHub with seleniumArgs: " + dataItem.args.join(" "), testWithData(dataItem));
+  });
+});

--- a/test/get-selenium-hub-test.js
+++ b/test/get-selenium-hub-test.js
@@ -2,16 +2,19 @@ var assert = require("assert")
 var getSeleniumHub = require('../lib/get-selenium-hub');
 
 describe('getSeleniumHub', function () {
-  var data = [{args: [], expected: 'http://localhost:4444/wd/hub/status'},
-              {args: ['-port', '5555'], expected: 'http://localhost:5555/wd/hub/status'},
-              {args: ['-hub', 'http://foo/wd/register'], expected: 'http://foo:4444/wd/hub/status'},
-              {args: ['-hub', 'http://foo:6666/wd/register'], expected: 'http://foo:6666/wd/hub/status'},
-              {args: ['-hub', 'http://foo/wd/register', '-port', '7777'], expected: 'http://foo:7777/wd/hub/status'},
-              {args: ['-hub', 'http://foo:6666/wd/register', '-port', '7777'], expected: 'http://foo:7777/wd/hub/status'}];
+  var data = [{args: [], expectedHostPort: 'localhost:4444'},
+              {args: ['-port', '5555'], expectedHostPort: 'localhost:5555'},
+              {args: ['-hub', 'http://foo/wd/register'], expectedHostPort: 'foo:4444'},
+              {args: ['-hub', 'http://foo:6666/wd/register'], expectedHostPort: 'foo:6666'},
+              {args: ['-hub', 'http://foo/wd/register', '-port', '7777'], expectedHostPort: 'foo:7777'},
+              {args: ['-hub', 'http://foo:6666/wd/register', '-port', '7777'], expectedHostPort: 'foo:7777'}];
 
   var testWithData = function (dataItem) {
     return function () {
-      assert.equal(getSeleniumHub(dataItem.args), dataItem.expected);
+      var actual = getSeleniumHub(dataItem.args);
+      var expected = 'http://' + dataItem.expectedHostPort + '/wd/hub/status';
+
+      assert.equal(actual, expected);
     };
   };
 


### PR DESCRIPTION
Adding support for parsing `-hub` argument, if provided, and using accompanying hostname and port values from said argument instead of 'localhost' and '4444'.  If a `-port` arg is also supplied, this value will take precedence.