### PR TITLE
Add integration example Gulp + WebdriverIO + Mocha

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,7 @@ selenium.start({
   // child.stderr now sent to your `process.stderr`
 });
 ```
+
+### Examples of combining with other tools
+
+- [Gulp + WebdriverIO + Mocha](http://twin.github.io/selenium-testing-workflow-with-webdriverio/)


### PR DESCRIPTION
selenium-standalone was a missing ingredient in my workflow, so I wrote a post about integrating it with WebdriverIO + Gulp + Mocha.

At first I was struggling a bit because the recommended usage seemed to be installing and running it globally, and I wanted to run it programmatically to minimize any global deps. Finally, I came up this and it seems to work very well.

If you don't think it's useful, feel free to close :wink: 