### PR TITLE
Optional Chrome and IE drivers. Fixes #123.

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -13,27 +13,32 @@ function computeDownloadUrls(opts) {
   // 2.44.0 would be `patch`, 2.44 `minor`, 2 `major` as per semver
   var minorSeleniumVersion = opts.seleniumVersion.slice(0, opts.seleniumVersion.lastIndexOf('.'));
 
-  return {
+  var downloadUrls = {
     selenium: util.format(
       urls.selenium,
       opts.seleniumBaseURL,
       minorSeleniumVersion,
       opts.seleniumVersion
-    ),
-    chrome: util.format(
+    )
+  };
+  if (opts.drivers.chrome) {
+    downloadUrls.chrome = util.format(
       urls.chrome,
       opts.drivers.chrome.baseURL,
       opts.drivers.chrome.version,
       getChromeDriverPlatform(opts.drivers.chrome.arch)
-    ),
-    ie: util.format(
+    );
+  }
+  if (opts.drivers.ie) {
+    downloadUrls.ie = util.format(
       urls.ie,
       opts.drivers.ie.baseURL,
       minorSeleniumVersion,
       getIeDriverArchitecture(opts.drivers.ie.arch),
       opts.drivers.ie.version
-    )
-  };
+    );
+  }
+  return downloadUrls;
 }
 
 function getChromeDriverPlatform(wantedArchitecture) {

--- a/lib/compute-fs-paths.js
+++ b/lib/compute-fs-paths.js
@@ -5,16 +5,20 @@ var path = require('path');
 var basePath = path.join(__dirname, '..', '.selenium');
 
 function computeFsPaths(opts) {
-  var fsPaths = {
-    chrome: {
+  var fsPaths = {};
+  if (opts.drivers.chrome) {
+    fsPaths.chrome = {
       installPath: path.join(basePath, 'chromedriver', opts.drivers.chrome.version + '-' + opts.drivers.chrome.arch + '-chromedriver')
-    },
-    ie: {
+    };
+  }
+  if (opts.drivers.ie) {
+    fsPaths.ie = {
       installPath: path.join(basePath, 'iedriver', opts.drivers.ie.version + '-' + opts.drivers.ie.arch + '-IEDriverServer.exe')
-    },
-    selenium: {
-      installPath: path.join(basePath, 'selenium-server', opts.seleniumVersion + '-server.jar')
-    }
+    };
+  }
+
+  fsPaths.selenium = {
+    installPath: path.join(basePath, 'selenium-server', opts.seleniumVersion + '-server.jar')
   };
 
   fsPaths = Object.keys(fsPaths).reduce(function computeDownloadPath(newFsPaths, name) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -62,15 +62,20 @@ function install(opts, cb) {
 
   logInstallSummary(logger, fsPaths, urls);
 
-  async.series([
+  var tasks = [
     createDirs.bind(null, fsPaths),
     download.bind(null, {
       urls: urls,
       fsPaths: fsPaths
     }),
-    chmodChromeDr.bind(null, fsPaths.chrome.installPath),
     asyncLogEnd.bind(null, logger),
-  ], cb);
+  ];
+
+  if (fsPaths.chrome) {
+    tasks.push(chmodChromeDr.bind(null, fsPaths.chrome.installPath));
+  }
+
+  async.series(tasks, cb);
 
   function onlyInstallMissingFiles(opts, cb) {
     async.series([
@@ -101,13 +106,17 @@ function install(opts, cb) {
       installer: installSelenium,
       from: opts.urls.selenium,
       to: opts.fsPaths.selenium.downloadPath
-    }, {
-      installer: installChromeDr,
-      from: opts.urls.chrome,
-      to: opts.fsPaths.chrome.downloadPath
     }];
 
-    if (process.platform === 'win32') {
+    if (opts.fsPaths.chrome) {
+      installers.push({
+        installer: installChromeDr,
+        from: opts.urls.chrome,
+        to: opts.fsPaths.chrome.downloadPath
+      });
+    }
+
+    if (process.platform === 'win32' && opts.fsPaths.ie) {
       installers.push({
         installer: installIeDr,
         from: opts.urls.ie,

--- a/lib/start.js
+++ b/lib/start.js
@@ -47,11 +47,14 @@ function start(opts, cb) {
 
   var args = [
     '-jar',
-    fsPaths.selenium.installPath,
-    '-Dwebdriver.chrome.driver=' + fsPaths.chrome.installPath
+    fsPaths.selenium.installPath
   ];
 
-  if (process.platform === 'win32') {
+  if (fsPaths.chrome) {
+    args.push('-Dwebdriver.chrome.driver=' + fsPaths.chrome.installPath);
+  }
+
+  if (process.platform === 'win32' && fsPaths.ie) {
     args.push('-Dwebdriver.ie.driver=' + fsPaths.ie.installPath);
   } else {
     delete fsPaths.ie;


### PR DESCRIPTION
This makes Chrome and IE drivers optional. The default behavior remains (for backwards compatibility) to include them in both `install` and `start`, but they can be disabled as follows:

```js
{
  drivers: {
    chrome: false,
    ie: false
  }
}
```
