### PR TITLE
Fix critical bug

### DIFF
--- a/lib/get-selenium-status-url.js
+++ b/lib/get-selenium-status-url.js
@@ -1,6 +1,6 @@
 module.exports = getSeleniumStatusUrl;
 
-var URI = require('URIjs');
+var URI = require('urijs');
 
 function getSeleniumStatusUrl(seleniumArgs) {
   var port = 4444;


### PR DESCRIPTION
This fixes the following:

```
starfall@nx:~/workspace/backuphamster-deployment$ selenium-standalone start
module.js:338
    throw err;
          ^
Error: Cannot find module 'URIjs'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/home/starfall/.npm-packages/lib/node_modules/selenium-standalone/lib/get-selenium-status-url.js:3:11)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
```

Could you please release a new version?