### PR TITLE
Update get-selenium-status-url.js

### DIFF
--- a/lib/get-selenium-status-url.js
+++ b/lib/get-selenium-status-url.js
@@ -1,6 +1,6 @@
 module.exports = getSeleniumStatusUrl;
 
-var URI = require('URIjs');
+var URI = require('urijs');
 
 function getSeleniumStatusUrl(seleniumArgs) {
   var port = 4444;


### PR DESCRIPTION
fix https://github.com/vvo/selenium-standalone/issues/133
```
module.js:338
    throw err;
    ^

Error: Cannot find module 'URIjs'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/home/olivier/SplitMe-app/node_modules/selenium-standalone/lib/get-selenium-status-url.js:3:11)
    at Module._compile (module.js:434:26)
    at Object.Module._extensions..js (module.js:452:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```