### PR TITLE
Add install `--silent` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ selenium-standalone start
 selenium-standalone install
 selenium-standalone start
 
+# install defaults, but silently
+selenium-standalone install --silent
+
 # specify selenium args, everything after -- is for selenium
 selenium-standalone start -- -debug
 

--- a/bin/selenium-standalone
+++ b/bin/selenium-standalone
@@ -37,7 +37,7 @@ which('java', function javaFound(err, javaPath) {
     stdio: 'inherit'
   };
 
-  options.logger = console.log;
+  options.logger = options.silent ? null : console.log;
   options.javaPath = javaPath;
 
   actions[action](options);
@@ -77,9 +77,9 @@ var actions = {
     var bar;
     var firstProgress = true;
 
-    selenium.install(options, installed);
+    options.progressCb = options.silent ? null : progressCb;
 
-    options.progressCb = progressCb;
+    selenium.install(options, installed);
 
     function installed(err) {
       if (err) {


### PR DESCRIPTION
It'll allow transparent installation using npm scripts, like in the following
`package.json` example:

```json
{
  "scripts":{
    "install":"echo 'Installing selenium...'; selenium-standalone install --silent"
  }
}
```