### PR TITLE
Process can incorrectly terminate when running as a grid node

### DIFF
--- a/lib/check-started.js
+++ b/lib/check-started.js
@@ -19,7 +19,8 @@ function checkStarted(seleniumArgs, cb) {
     }
 
     request(hub, function (err, res) {
-      if (err || res.statusCode !== 200) {
+      var success = res && res.body && res.body.success === true;
+      if (err || res.statusCode !== 200 || !success) {
         setTimeout(hasStarted, retryInterval);
         return;
       }

--- a/lib/check-started.js
+++ b/lib/check-started.js
@@ -1,11 +1,11 @@
 module.exports = checkStarted;
 
 var request = require('request').defaults({json: true});
-var getSeleniumStatusUrl = require('./get-selenium-status-url.js');
+var statusUrl = require('./get-selenium-status-url.js');
 
 function checkStarted(seleniumArgs, cb) {
   var retries = 0;
-  var hub = getSeleniumStatusUrl(seleniumArgs);
+  var hub = statusUrl.getSeleniumStatusUrl(seleniumArgs);
   // server has one minute to start
   var retryInterval = 200;
   var maxRetries = 60 * 1000 / retryInterval;
@@ -19,8 +19,7 @@ function checkStarted(seleniumArgs, cb) {
     }
 
     request(hub, function (err, res) {
-      var success = res && res.body && res.body.success === true;
-      if (err || res.statusCode !== 200 || !success) {
+      if (err || res.statusCode !== 200) {
         setTimeout(hasStarted, retryInterval);
         return;
       }

--- a/lib/get-selenium-status-url.js
+++ b/lib/get-selenium-status-url.js
@@ -9,6 +9,9 @@ function getSeleniumStatusUrl(seleniumArgs) {
   var hubArg = seleniumArgs.indexOf('-hub');
   var roleArg = seleniumArgs.indexOf('-role');
 
+  var nodeStatusAPIPath = '/wd/hub/status';
+  var hubStatusAPIPath = '/grid/api/hub';
+
   if (hubArg !== -1) {
     hubURI = new URI(seleniumArgs[hubArg + 1]);
     hostname = hubURI.hostname() || hostname;
@@ -21,10 +24,10 @@ function getSeleniumStatusUrl(seleniumArgs) {
         if(hubArg === -1){
           port = portArg !== -1 ? seleniumArgs[portArg + 1] : 5555;
         }
-        return 'http://' + hostname + ':' + port + '/wd/hub/status';
+        return 'http://' + hostname + ':' + port + hubStatusAPIPath;
       case 'hub':
         port = portArg !== -1 ? seleniumArgs[portArg + 1] : 4444;
-        return 'http://localhost:' + port + '/api/grid/hub/';
+        return 'http://localhost:' + port + hubStatusAPIPath;
     }
   }
 
@@ -32,5 +35,5 @@ function getSeleniumStatusUrl(seleniumArgs) {
     port = seleniumArgs[portArg + 1];
   }
 
-  return 'http://' + hostname + ':' + port + '/wd/hub/status';
+  return 'http://' + hostname + ':' + port + nodeStatusAPIPath;
 }

--- a/lib/get-selenium-status-url.js
+++ b/lib/get-selenium-status-url.js
@@ -19,8 +19,10 @@ exports.getSeleniumStatusUrl = function(seleniumArgs) {
   var processType = this.getRunningProcessType(seleniumArgs);
   var portArg = seleniumArgs.indexOf('-port');
   var port = (portArg !== -1) ? seleniumArgs[portArg + 1] : undefined;
+  var hostArg = seleniumArgs.indexOf('-host');
+  var host = (hostArg !== -1) ? seleniumArgs[hostArg + 1] : 'localhost';
 
-  var statusURI = new URI('http://localhost');
+  var statusURI = new URI('http://' + host);
   var nodeStatusAPIPath = '/wd/hub/status';
   var hubStatusAPIPath = '/grid/api/hub';
 

--- a/lib/get-selenium-status-url.js
+++ b/lib/get-selenium-status-url.js
@@ -50,24 +50,3 @@ exports.getSeleniumStatusUrl = function(seleniumArgs) {
 
   return statusURI.toString();
 }
-
-exports.getRemoteSeleniumHubStatusUrl = function(seleniumArgs) {
-  var processType = this.getRunningProcessType(seleniumArgs);
-  var hubArg = seleniumArgs.indexOf('-hub');
-  var statusURI = (hubArg !== -1) ? new URI(seleniumArgs[hubArg + 1]) : new URI('http://localhost:4444');
-  statusURI.path('/grid/api/hub');
-
-  switch (processType) {
-    case PROCESS_TYPES.STANDALONE:
-    case PROCESS_TYPES.GRID_HUB:
-      // Standalone servers and grid hubs ignore the `-hub` argument, so the
-      // status URLs will be the same the status URLs for itself.
-      return this.getSeleniumStatusUrl(seleniumArgs);
-    case PROCESS_TYPES.GRID_NODE:
-      // Grid nodes will either connect to the default localhost:4444 hub, or the
-      // one specified by the `-hub` argument.
-      return statusURI.toString();
-    default:
-      throw 'ERROR: Trying to run selenium in an unknown way.';
-  }
-}

--- a/lib/get-selenium-status-url.js
+++ b/lib/get-selenium-status-url.js
@@ -1,39 +1,71 @@
-module.exports = getSeleniumStatusUrl;
-
 var URI = require('urijs');
+var PROCESS_TYPES = exports.PROCESS_TYPES = {
+  STANDALONE: 0,
+  GRID_HUB: 1,
+  GRID_NODE: 2
+};
 
-function getSeleniumStatusUrl(seleniumArgs) {
-  var port = 4444;
-  var hostname = 'localhost';
-  var portArg = seleniumArgs.indexOf('-port');
-  var hubArg = seleniumArgs.indexOf('-hub');
+exports.getRunningProcessType = function(seleniumArgs) {
   var roleArg = seleniumArgs.indexOf('-role');
+  var role = (roleArg !== -1) ? seleniumArgs[roleArg + 1] : undefined;
 
+  if (roleArg === -1) return PROCESS_TYPES.STANDALONE;
+  else if (role === 'hub') return PROCESS_TYPES.GRID_HUB;
+  else if (role === 'node') return PROCESS_TYPES.GRID_NODE;
+  else return undefined;
+}
+
+exports.getSeleniumStatusUrl = function(seleniumArgs) {
+  var processType = this.getRunningProcessType(seleniumArgs);
+  var portArg = seleniumArgs.indexOf('-port');
+  var port = (portArg !== -1) ? seleniumArgs[portArg + 1] : undefined;
+
+  var statusURI = new URI('http://localhost');
   var nodeStatusAPIPath = '/wd/hub/status';
   var hubStatusAPIPath = '/grid/api/hub';
 
-  if (hubArg !== -1) {
-    hubURI = new URI(seleniumArgs[hubArg + 1]);
-    hostname = hubURI.hostname() || hostname;
-    port = hubURI.port() || port;
+  switch (processType) {
+    case PROCESS_TYPES.STANDALONE:
+      statusURI.port(4444);
+      statusURI.path(nodeStatusAPIPath);
+      break;
+    case PROCESS_TYPES.GRID_HUB:
+      statusURI.port(4444);
+      statusURI.path(hubStatusAPIPath);
+      break;
+    case PROCESS_TYPES.GRID_NODE:
+      statusURI.port(5555);
+      statusURI.path(nodeStatusAPIPath);
+      break;
+    default:
+      throw 'ERROR: Trying to run selenium in an unknown way.';
   }
 
-  if (roleArg !== -1) {
-    switch(seleniumArgs[roleArg + 1]){
-      case 'node':
-        if(hubArg === -1){
-          port = portArg !== -1 ? seleniumArgs[portArg + 1] : 5555;
-        }
-        return 'http://' + hostname + ':' + port + hubStatusAPIPath;
-      case 'hub':
-        port = portArg !== -1 ? seleniumArgs[portArg + 1] : 4444;
-        return 'http://localhost:' + port + hubStatusAPIPath;
-    }
-  }
-
+  // Running with a non-default port
   if (portArg !== -1) {
-    port = seleniumArgs[portArg + 1];
+    statusURI.port(seleniumArgs[portArg + 1]);
   }
 
-  return 'http://' + hostname + ':' + port + nodeStatusAPIPath;
+  return statusURI.toString();
+}
+
+exports.getRemoteSeleniumHubStatusUrl = function(seleniumArgs) {
+  var processType = this.getRunningProcessType(seleniumArgs);
+  var hubArg = seleniumArgs.indexOf('-hub');
+  var statusURI = (hubArg !== -1) ? new URI(seleniumArgs[hubArg + 1]) : new URI('http://localhost:4444');
+  statusURI.path('/grid/api/hub');
+
+  switch (processType) {
+    case PROCESS_TYPES.STANDALONE:
+    case PROCESS_TYPES.GRID_HUB:
+      // Standalone servers and grid hubs ignore the `-hub` argument, so the
+      // status URLs will be the same the status URLs for itself.
+      return this.getSeleniumStatusUrl(seleniumArgs);
+    case PROCESS_TYPES.GRID_NODE:
+      // Grid nodes will either connect to the default localhost:4444 hub, or the
+      // one specified by the `-hub` argument.
+      return statusURI.toString();
+    default:
+      throw 'ERROR: Trying to run selenium in an unknown way.';
+  }
 }

--- a/test/get-selenium-hub-test.js
+++ b/test/get-selenium-hub-test.js
@@ -38,12 +38,14 @@ describe('getSeleniumStatusUrl', function () {
               // Started as a Selenium Grid hub
               {args: ['-role', 'hub'], expectedUrl: 'localhost:4444' + hubStatusAPIPath},
               {args: ['-role', 'hub', '-port', '12345'], expectedUrl: 'localhost:12345' + hubStatusAPIPath},
+              {args: ['-role', 'hub', '-host', 'alias', '-port', '12345'], expectedUrl: 'alias:12345' + hubStatusAPIPath},
               {args: ['-role', 'hub', '-hub', 'http://foo/wd/register'], expectedUrl: 'localhost:4444' + hubStatusAPIPath},
               {args: ['-role', 'hub', '-hub', 'http://foo:6666/wd/register', '-port', '12345'], expectedUrl: 'localhost:12345' + hubStatusAPIPath},
 
               // Started as a Selenium Grid node
               {args: ['-role', 'node'], expectedUrl: 'localhost:5555' + nodeStatusAPIPath},
               {args: ['-role', 'node', '-port', '7777'], expectedUrl: 'localhost:7777' + nodeStatusAPIPath},
+              {args: ['-role', 'node', '-host', 'alias', '-port', '7777'], expectedUrl: 'alias:7777' + nodeStatusAPIPath},
               {args: ['-role', 'node', '-hub', 'http://foo/wd/register'], expectedUrl: 'localhost:5555' + nodeStatusAPIPath},
               {args: ['-role', 'node', '-hub', 'http://foo:6666/wd/register', '-port', '7777'], expectedUrl: 'localhost:7777' + nodeStatusAPIPath}
             ];

--- a/test/get-selenium-hub-test.js
+++ b/test/get-selenium-hub-test.js
@@ -63,39 +63,3 @@ describe('getSeleniumStatusUrl', function () {
     it('getSeleniumStatusUrl with seleniumArgs: ' + dataItem.args.join(' '), testWithData(dataItem));
   });
 });
-
-describe('getRemoteSeleniumHubStatusUrl', function () {
-  var data = [
-              // Started as a standalone Selenium Server
-              {args: [], expectedUrl: 'localhost:4444' + nodeStatusAPIPath},
-              {args: ['-port', '5678'], expectedUrl: 'localhost:5678' + nodeStatusAPIPath},
-              {args: ['-hub', 'http://foo/wd/register'], expectedUrl: 'localhost:4444' + nodeStatusAPIPath},
-              {args: ['-hub', 'http://foo:6666/wd/register', '-port', '7777'], expectedUrl: 'localhost:7777' + nodeStatusAPIPath},
-
-              // Started as a Selenium Grid hub
-              {args: ['-role', 'hub'], expectedUrl: 'localhost:4444' + hubStatusAPIPath},
-              {args: ['-role', 'hub', '-port', '12345'], expectedUrl: 'localhost:12345' + hubStatusAPIPath},
-              {args: ['-role', 'hub', '-hub', 'http://foo/wd/register'], expectedUrl: 'localhost:4444' + hubStatusAPIPath},
-              {args: ['-role', 'hub', '-hub', 'http://foo:6666/wd/register', '-port', '12345'], expectedUrl: 'localhost:12345' + hubStatusAPIPath},
-
-              // Started as a Selenium Grid node
-              {args: ['-role', 'node'], expectedUrl: 'localhost:4444' + hubStatusAPIPath},
-              {args: ['-role', 'node', '-port', '7777'], expectedUrl: 'localhost:4444' + hubStatusAPIPath},
-              {args: ['-role', 'node', '-hub', 'http://foo/wd/register'], expectedUrl: 'foo' + hubStatusAPIPath},
-              {args: ['-role', 'node', '-hub', 'http://foo:6666/wd/register', '-port', '7777'], expectedUrl: 'foo:6666' + hubStatusAPIPath}
-            ];
-
-  var testWithData = function (dataItem) {
-    return function () {
-      var actual = statusUrl.getRemoteSeleniumHubStatusUrl(dataItem.args);
-      var expected = 'http://' + dataItem.expectedUrl;
-
-      assert.equal(actual, expected);
-    };
-  };
-
-  data.forEach(function (dataItem) {
-    it('getRemoteSeleniumHubStatusUrl with seleniumArgs: ' + dataItem.args.join(' '), testWithData(dataItem));
-  });
-});
-

--- a/test/get-selenium-hub-test.js
+++ b/test/get-selenium-hub-test.js
@@ -1,17 +1,25 @@
 var assert = require("assert");
 var getSeleniumStatusUrl = require('../lib/get-selenium-status-url');
-var nodeUriPath = '/wd/hub/status';
+var nodeStatusAPIPath = '/wd/hub/status';
+var hubStatusAPIPath = '/grid/api/hub';
 
 describe('getSeleniumStatusUrl', function () {
-  var data = [{args: [], expectedUrl: 'localhost:4444' + nodeUriPath},
-              {args: ['-port', '5555'], expectedUrl: 'localhost:5555' + nodeUriPath},
-              {args: ['-hub', 'http://foo/wd/register'], expectedUrl: 'foo:4444' + nodeUriPath},
-              {args: ['-role', 'hub'], expectedUrl: 'localhost:4444/api/grid/hub/'},
-              {args: ['-role', 'node'], expectedUrl: 'localhost:5555' + nodeUriPath},
-              {args: ['-role', 'node', '-hub', 'http://foo:6666/wd/register'], expectedUrl: 'foo:6666' + nodeUriPath},
-              {args: ['-hub', 'http://foo:6666/wd/register'], expectedUrl: 'foo:6666' + nodeUriPath},
-              {args: ['-hub', 'http://foo/wd/register', '-port', '7777'], expectedUrl: 'foo:7777' + nodeUriPath},
-              {args: ['-hub', 'http://foo:6666/wd/register', '-port', '7777'], expectedUrl: 'foo:7777' + nodeUriPath}];
+  var data = [
+              // If started with both modes active, check the status of the `node`
+              {args: [], expectedUrl: 'localhost:4444' + nodeStatusAPIPath},
+              {args: ['-port', '5555'], expectedUrl: 'localhost:5555' + nodeStatusAPIPath},
+              {args: ['-hub', 'http://foo/wd/register'], expectedUrl: 'foo:4444' + nodeStatusAPIPath},
+              {args: ['-hub', 'http://foo:6666/wd/register'], expectedUrl: 'foo:6666' + nodeStatusAPIPath},
+              {args: ['-hub', 'http://foo/wd/register', '-port', '7777'], expectedUrl: 'foo:7777' + nodeStatusAPIPath},
+              {args: ['-hub', 'http://foo:6666/wd/register', '-port', '7777'], expectedUrl: 'foo:7777' + nodeStatusAPIPath},
+
+              // If started with only `hub` mode, only check status of itself
+              {args: ['-role', 'hub'], expectedUrl: 'localhost:4444' + hubStatusAPIPath},
+
+              // If started with only `node` mode, check status of remote hub instance
+              {args: ['-role', 'node'], expectedUrl: 'localhost:5555' + hubStatusAPIPath},
+              {args: ['-role', 'node', '-hub', 'http://foo:6666/wd/register'], expectedUrl: 'foo:6666' + hubStatusAPIPath}
+            ];
 
   var testWithData = function (dataItem) {
     return function () {

--- a/test/get-selenium-hub-test.js
+++ b/test/get-selenium-hub-test.js
@@ -5,7 +5,7 @@ var hubStatusAPIPath = '/grid/api/hub';
 
 describe('getSeleniumStatusUrl', function () {
   var data = [
-              // If started with both modes active, check the status of the `node`
+              // If started as a standalone node (not in a grid), check the status of itself
               {args: [], expectedUrl: 'localhost:4444' + nodeStatusAPIPath},
               {args: ['-port', '5555'], expectedUrl: 'localhost:5555' + nodeStatusAPIPath},
               {args: ['-hub', 'http://foo/wd/register'], expectedUrl: 'foo:4444' + nodeStatusAPIPath},
@@ -13,10 +13,10 @@ describe('getSeleniumStatusUrl', function () {
               {args: ['-hub', 'http://foo/wd/register', '-port', '7777'], expectedUrl: 'foo:7777' + nodeStatusAPIPath},
               {args: ['-hub', 'http://foo:6666/wd/register', '-port', '7777'], expectedUrl: 'foo:7777' + nodeStatusAPIPath},
 
-              // If started with only `hub` mode, only check status of itself
+              // If started with the `hub` role of the grid, check status of itself
               {args: ['-role', 'hub'], expectedUrl: 'localhost:4444' + hubStatusAPIPath},
 
-              // If started with only `node` mode, check status of remote hub instance
+              // If started with the `node` role of the grid, check status of remote hub instance
               {args: ['-role', 'node'], expectedUrl: 'localhost:5555' + hubStatusAPIPath},
               {args: ['-role', 'node', '-hub', 'http://foo:6666/wd/register'], expectedUrl: 'foo:6666' + hubStatusAPIPath}
             ];


### PR DESCRIPTION
When `selenium-standalone` is run with only the `-role node` mode, eventually the process will die because the server status URL is returning an error. Example:

![screen shot 2015-11-13 at 11 08 41](https://cloud.githubusercontent.com/assets/573423/11158971/b9e730ca-8a10-11e5-84c6-eb8d93e5c13a.png)

Looking at the only API documentation that I could find [0] and my own selenium test servers it appears that the `/wd/hub/status` API will always fail when called against the hub, but passes when called against a node. This PR changes to check against the `/grid/api/hub` API if running in a grid hub role (API to use was gotten from [0] and the selenium unit tests[1]). When running in a standalone mode or grid node, continue to use the existing API for checking status.

There was also some existing logic that tried to use the `-hub` parameter to decide what host the status check should query. It seems that the `checkStarted()` wants to know if the local process was started successfully, and not the status of the remote hub. There is now a new (unused) function `getRemoteSeleniumHubStatusUrl()` that can get the status URL for a remote hub if in the future there is a need to check for both the local process and the remote hub running.

---
[0] https://github.com/nicegraham/selenium-grid2-api/blob/master/README.md#wdhub
[1] https://github.com/SeleniumHQ/selenium/blob/master/java/server/test/org/openqa/grid/internal/StatusServletTests.java#L284