### PR TITLE
feat(upgrades): upgrade default versions

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,14 +1,14 @@
 module.exports = {
   baseURL: 'https://selenium-release.storage.googleapis.com',
-  version: '2.48.2',
+  version: '2.50.1',
   drivers: {
     chrome: {
-      version: '2.20',
+      version: '2.21',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
     ie: {
-      version: '2.48.0',
+      version: '2.50.0',
       arch: process.arch,
       baseURL: 'https://selenium-release.storage.googleapis.com'
     }


### PR DESCRIPTION
Selenium version `2.50.1` and IE version `2.50.0` via http://www.seleniumhq.org/download/
Chromedriver version `2.21` via https://chromedriver.storage.googleapis.com