### PR TITLE
Do not merge the install/start options with the default options.

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -3,7 +3,6 @@ module.exports = install;
 var async = require('async');
 var crypto = require('crypto');
 var fs = require('fs');
-var merge = require('lodash').merge;
 var mkdirp = require('mkdirp');
 var path = require('path');
 var request = require('request');
@@ -36,7 +35,9 @@ function install(opts, cb) {
 
   opts.progressCb = opts.progressCb || noop;
 
-  opts.drivers = merge(defaultConfig.drivers, opts.drivers || {});
+  if (!opts.drivers) {
+    opts.drivers = defaultConfig.drivers;
+  }
 
   logger('----------');
   logger('selenium-standalone installation starting');

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,6 +1,5 @@
 module.exports = start;
 
-var merge = require('lodash').merge;
 var spawn = require('child_process').spawn;
 
 var which = require('which');
@@ -29,7 +28,9 @@ function start(opts, cb) {
     opts.spawnCb = noop;
   }
 
-  opts.drivers = merge(defaultConfig.drivers, opts.drivers || {});
+  if (!opts.drivers) {
+    opts.drivers = defaultConfig.drivers;
+  }
 
   var fsPaths = computeFsPaths({
     seleniumVersion: opts.version,

--- a/test/programmatic.js
+++ b/test/programmatic.js
@@ -1,4 +1,8 @@
 describe('programmatic use', function () {
+  var containsChrome = function(arg) {
+    return /chrome/i.test(arg);
+  };
+
   it('should start', function(done) {
     this.timeout(60000);
     var selenium = require('../');
@@ -6,6 +10,31 @@ describe('programmatic use', function () {
       if (err) {
         done(err);
         return;
+      }
+
+      if (cp.spawnargs && !cp.spawnargs.some(containsChrome)) {
+        done(new Error('Chrome driver should be loaded'));
+      }
+
+      cp.kill();
+      done();
+    });
+  });
+
+  it('should use the given drivers', function(done) {
+    this.timeout(60000);
+    var selenium = require('../');
+    var options = {
+      drivers: {} // only built-in Firefox
+    };
+    selenium.start(options, function(err, cp) {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      if (cp.spawnargs && cp.spawnargs.some(containsChrome)) {
+        done(new Error('Chrome driver should not be loaded'));
       }
 
       cp.kill();


### PR DESCRIPTION
Fixes #128.

Let me know if this makes any sense. I tried to add a meaningful test, but `ChildProcess.spawnargs` is the only way I know to peek into the internals. It’s only available in newer Node versions. I’ve tested successfully with 0.10, 0.12 and 5.5, but only 5.5 can perform the `spawnargs` check.

This is an API-breaking change in terms of semver AFAICS. Existing code might depend on the fact that the default options are always merged in. Was there a specific reason to do this in the first hand?