### PR TITLE
Remove deprecated graceful-fs@3.x dependency

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -164,27 +164,18 @@ function install(opts, cb) {
   }
 
   function installZippedFile(from, to, cb) {
-    var unzip = require('unzip');
-
     getDownloadStream(from, function(err, stream) {
       if (err) {
         return cb(err);
       }
 
-      var extractPath = path.join(path.dirname(to), path.basename(to, '.zip'));
-
       // Store downloaded compressed file
-      stream.pipe(fs.createWriteStream(to));
+      var zipWriteStream = fs.createWriteStream(to)
+        .once('error', cb.bind(null, new Error('Could not write to ' + to)));
+      stream.pipe(zipWriteStream);
 
       // Uncompress downloaded file
-      stream.pipe(unzip.Parse())
-        .once('entry', function(file) {
-          file
-            .pipe(fs.createWriteStream(extractPath))
-            .once('error', cb.bind(null, new Error('Could not write to ' + to)))
-            .once('finish', cb);
-        })
-        .once('error', cb.bind(null, new Error('Could not unzip ' + from)));
+      zipWriteStream.once('finish', uncompressDownloadedFile.bind(null, to, cb));
     });
   }
 
@@ -212,6 +203,36 @@ function install(opts, cb) {
 
     // initiate request
     r.end();
+  }
+
+  function uncompressDownloadedFile(zipFilePath, cb) {
+    var yauzl = require('yauzl');
+    var extractPath = path.join(path.dirname(zipFilePath), path.basename(zipFilePath, '.zip'));
+
+    yauzl.open(zipFilePath, {lazyEntries: true}, function onOpenZipFile(err, zipFile) {
+      if (err) {
+        cb(err);
+        return;
+      }
+      zipFile.readEntry();
+      zipFile.once('entry', function (entry) {
+        zipFile.openReadStream(entry, function onOpenZipFileEntryReadStream(err, readStream) {
+          if (err) {
+            cb(err);
+            return;
+          }
+          var extractWriteStream = fs.createWriteStream(extractPath)
+            .once('error', cb.bind(null, new Error('Could not write to ' + extractPath)));
+          readStream
+            .pipe(extractWriteStream)
+            .once('error', cb.bind(null, new Error('Could not read ' + zipFilePath)))
+            .once('finish', function onExtracted() {
+              zipFile.close();
+              cb();
+            });
+        });
+      });
+    })
   }
 
   function updateProgressPercentage(chunk) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "author": "Vincent Voyer <vincent@zeroload.net>",
   "license": "MIT",
   "dependencies": {
-    "urijs": "1.16.1",
     "async": "1.2.1",
     "commander": "2.6.0",
     "lodash": "3.9.3",
@@ -29,8 +28,9 @@
     "mkdirp": "0.5.0",
     "progress": "1.1.8",
     "request": "2.51.0",
-    "unzip": "0.1.11",
-    "which": "1.1.1"
+    "urijs": "1.16.1",
+    "which": "1.1.1",
+    "yauzl": "^2.5.0"
   },
   "devDependencies": {
     "mocha": "2.1.0"


### PR DESCRIPTION
Replaces unmaintained unzip dependency with yauzl.
This removes the indirect dependency to the deprecated graceful-fs@3.x.