### PR TITLE
Mention default config in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ selenium-standalone start -- -role node -hub http://localhost:4444/grid/register
 
 ## Application Programming Interface (API)
 
+### Sample configuration object
+Here you can find an up-to-date example of the configuration object:
+[lib/default-config.js](lib/default-config.js)
+
 ### Example
 
 ```js


### PR DESCRIPTION
The file which is actually holding the up-to-date default config is not mentioned anywhere in the Readme. (It is `lib/default-config.js`)