### PR TITLE
Fix building previous chromedriver version urls

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -9,6 +9,8 @@ var urls = {
   firefox: '%s/v%s/geckodriver-%s-%s'
 };
 
+var mac32;
+
 function computeDownloadUrls(opts, askedOpts) {
   // 2.44.0 => 2.44
   // 2.44.0 would be `patch`, 2.44 `minor`, 2 `major` as per semver
@@ -22,6 +24,9 @@ function computeDownloadUrls(opts, askedOpts) {
     )
   };
   if (opts.drivers.chrome) {
+    if (opts.drivers.chrome.version < 2.23) {
+      mac32 = true;
+    }
     downloadUrls.chrome = util.format(
       urls.chrome,
       opts.drivers.chrome.baseURL,
@@ -56,7 +61,11 @@ function getChromeDriverPlatform(wantedArchitecture) {
   if (process.platform === 'linux') {
     platform = 'linux' + (wantedArchitecture === 'x64' ? '64' : '32');
   } else if (process.platform === 'darwin') {
-    platform = 'mac64';
+    if (mac32) {
+      platform = 'mac32';
+    } else {
+      platform = 'mac64';
+    }
   } else {
     platform = 'win32';
   }


### PR DESCRIPTION
* On versions of Chromedriver < 2.23 the filename ends with `mac32`.
* With this fix, attempting to install chromedriver 2.22 and earlier via `selenium-standalone install` will succeed. This was called out in https://github.com/vvo/selenium-standalone/issues/209

To Test:
```
selenium-standalone install --drivers.chrome.version=2.22 --drives.chrome.baseURL=https://chromedriver.storage.googleapis.com
```  

@vvo @nkbt