### PR TITLE
Stabilize unit tests in travis-ci 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
+sudo: false
+
 language: node_js
 node_js: stable


### PR DESCRIPTION
Did some research into fixing the travis-ci builds since the unit tests have been failing for some time, but always pass locally. Selenium has a problem where if it was started and stopped in quick succession, the startup time would get longer and longer [0]. This is basically what is going on with our unit tests. Specifically, the problem with with how Selenium is getting a random session [1]. The Travis build environment appears to have very low entropy [2] which heightens the chance of hitting this problem.

There were a handful of workarounds listed in the below references that never really seemed to pan out and get consistently passing tests. What did work? Using the new travis-ci container-based infrastructure [3] gives us not only consistently passing tests, but also much quicker execution times.

---
[0] https://groups.google.com/forum/#!msg/selenium-users/GwI96I1JOJk/MUVzMNOI5M4J
[1] https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/1301
[2] https://github.com/travis-ci/travis-ci/issues/1494
[3] https://docs.travis-ci.com/user/migrating-from-legacy/