### PR TITLE
Test cases for constructing download URLs

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -11,6 +11,30 @@ var urls = {
 
 var mac32;
 
+/**
+ * Computes the URL to download selenium.jar and drivers.
+ * 
+ * When passing in the `opts.drivers` param, it must be of the following format. Each of the drivers listed
+ * inside is optional
+ * 
+ * {
+ *   chrome: { ... },
+ *   ie: { ... },
+ *   firefox: { ... }
+ * }
+ * 
+ * Each driver must have the following format.
+ * 
+ * {
+ *   baseURL: '',  // Base URL for where to download driver from
+ *   version: '',  // Version number string that matches the desired driver version
+ *   arch: ''      // Architecture for the desired driver
+ * }
+ *
+ * @param {string} opts.seleniumVersion - Version number string that matches the desired selenium.jar
+ * @param {string} opts.seleniumBaseURL - Base URL for where to download selenium.jar from
+ * @param {Object} opts.drivers - Object containing options for various drivers. See comment for object format.
+ */
 function computeDownloadUrls(opts, askedOpts) {
   // 2.44.0 => 2.44
   // 2.44.0 would be `patch`, 2.44 `minor`, 2 `major` as per semver

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -160,7 +160,7 @@ describe('compute-download-urls', function() {
     describe('win', function() {
       before(function() {
         Object.defineProperty(process, 'platform', {
-          value: 'win'
+          value: 'win32'
         });
       });
 
@@ -189,15 +189,150 @@ describe('compute-download-urls', function() {
     });
     
     describe('linux', function() {
+      before(function() {
+        Object.defineProperty(process, 'platform', {
+          value: 'linux'
+        });
+      });
 
+      it('uses `wires` name for versions < 0.8.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.7.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.firefox, 'https://localhost/v0.7.0/wires-0.7.0-linux64.gz');
+      });
+
+      it('uses `geckodriver` name for versions >= 0.8.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.8.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.firefox, 'https://localhost/v0.8.0/geckodriver-0.8.0-linux64.gz');
+      });
+
+      it('uses correct directory for 0.3.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.3.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.firefox, 'https://localhost/0.3.0/wires-0.3.0-linux64.gz');
+      });
+
+      it('uses leading `v` in version string when >= 0.9.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.9.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.firefox, 'https://localhost/v0.9.0/geckodriver-v0.9.0-linux64.tar.gz');
+      });
+
+      it('uses plain version string when < 0.9.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.7.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.firefox, 'https://localhost/v0.7.0/wires-0.7.0-linux64.gz');
+      });
+
+      it('uses `.gz` file extension for versions < 0.9.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.8.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert(actual.firefox.indexOf('.gz') > 0);
+        assert(actual.firefox.indexOf('.tar.gz') === -1);
+      });
+
+      it('uses `.tar.gz` file extension for versions >= 0.9.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.9.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert(actual.firefox.indexOf('.tar.gz') > 0);
+      });
     });
 
     describe('mac', function() {
+      before(function() {
+        Object.defineProperty(process, 'platform', {
+          value: 'darwin'
+        });
+      });
 
+      it('uses `OSX` platform for versions < 0.9.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.8.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert(actual.firefox.indexOf('OSX') > 0);
+      });
+
+      it('uses `mac` platform for versions == 0.9.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.9.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert(actual.firefox.indexOf('mac') > 0);
+        assert(actual.firefox.indexOf('macos') === -1);
+      });
+
+      it('uses `macos` platform for versions >= 0.10.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.10.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert(actual.firefox.indexOf('macos') > 0);
+      });
     });
 
     describe('win', function() {
+      before(function() {
+        Object.defineProperty(process, 'platform', {
+          value: 'win32'
+        });
+      });
 
+      it('uses leading `v` in version string when == 0.5.0', function() {
+        opts.drivers.firefox = {
+          baseURL: 'https://localhost',
+          version: '0.5.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.firefox, 'https://localhost/v0.5.0/wires-v0.5.0-win64.zip');
+      });
     });
   });
 

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -1,0 +1,132 @@
+var assert = require('assert');
+
+var computeDownloadUrls = require('../lib/compute-download-urls');
+
+/*
+default-config
+
+module.exports = {
+  baseURL: 'https://selenium-release.storage.googleapis.com',
+  version: '2.53.1',
+  drivers: {
+    chrome: {
+      version: '2.23',
+      arch: process.arch,
+      baseURL: 'https://chromedriver.storage.googleapis.com'
+    },
+    ie: {
+      version: '2.53.1',
+      arch: process.arch,
+      baseURL: 'https://selenium-release.storage.googleapis.com'
+    },
+    firefox: {
+      version: '0.10.0',
+      arch: process.arch,
+      baseURL: 'https://github.com/mozilla/geckodriver/releases/download'
+    }
+  }
+};
+*/
+
+/**
+ * Tests for the `computeDownloadUrls` module.
+ * 
+ * NOTE: This does not verify that the module is returning valid URLs that will respond with
+ * the desired binary files. Just that the logic contained in the module, specifically for
+ * handling when paths formats differ between versions of the same driver.
+ */
+describe('compute-download-urls', function() {
+  var opts;
+  
+  describe('selenium-jar', function() {
+    it('basic version', function() {
+      var actual = computeDownloadUrls({
+        seleniumVersion: '1.0',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {}
+      });
+
+      assert.equal(actual.selenium, 'https://localhost/1.0/selenium-server-standalone-1.0.jar');
+    });
+
+    it('version with patch', function() {
+      var actual = computeDownloadUrls({
+        seleniumVersion: '1.0.1',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {}
+      });
+
+      assert.equal(actual.selenium, 'https://localhost/1.0/selenium-server-standalone-1.0.1.jar');
+    });
+
+    it('version with beta string', function() {
+      var actual = computeDownloadUrls({
+        seleniumVersion: '3.0.0-beta2',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {}
+      });
+
+      assert.equal(actual.selenium, 'https://localhost/3.0-beta2/selenium-server-standalone-3.0.0-beta2.jar');
+    });
+  });
+
+  describe('chrome', function() {
+    beforeEach(function() {
+      opts = {
+        seleniumVersion: '1.0',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {
+          chrome: {}
+        }
+      };
+    });
+    
+    describe('linux', function() {
+
+    });
+
+    describe('mac', function() {
+
+    });
+
+    describe('win', function() {
+
+    });
+  });
+
+  describe('firefox', function() {
+    beforeEach(function() {
+      opts = {
+        seleniumVersion: '1.0',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {
+          firefox: {}
+        }
+      };
+    });
+    
+    describe('linux', function() {
+
+    });
+
+    describe('mac', function() {
+
+    });
+
+    describe('win', function() {
+
+    });
+  });
+
+  describe('ie', function() {
+    beforeEach(function() {
+      opts = {
+        seleniumVersion: '1.0',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {
+          ie: {}
+        }
+      };
+    });
+  });
+});

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -2,32 +2,6 @@ var assert = require('assert');
 
 var computeDownloadUrls;
 
-/*
-default-config
-
-module.exports = {
-  baseURL: 'https://selenium-release.storage.googleapis.com',
-  version: '2.53.1',
-  drivers: {
-    chrome: {
-      version: '2.23',
-      arch: process.arch,
-      baseURL: 'https://chromedriver.storage.googleapis.com'
-    },
-    ie: {
-      version: '2.53.1',
-      arch: process.arch,
-      baseURL: 'https://selenium-release.storage.googleapis.com'
-    },
-    firefox: {
-      version: '0.10.0',
-      arch: process.arch,
-      baseURL: 'https://github.com/mozilla/geckodriver/releases/download'
-    }
-  }
-};
-*/
-
 /**
  * Tests for the `computeDownloadUrls` module.
  * 

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -337,6 +337,12 @@ describe('compute-download-urls', function() {
   });
 
   describe('ie', function() {
+    before(function() {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32'
+      });
+    });
+
     beforeEach(function() {
       opts = {
         seleniumVersion: '1.0',
@@ -345,6 +351,40 @@ describe('compute-download-urls', function() {
           ie: {}
         }
       };
+    });
+
+    it('uses `Win32` platform when arch == ia32', function() {
+      opts.drivers.ie = {
+        baseURL: 'https://localhost',
+        version: '2.20.0',
+        arch: 'ia32'
+      }
+
+      var actual = computeDownloadUrls(opts);
+      assert(actual.ie.indexOf('IEDriverServer_Win32') > 0);
+    });
+
+    it('uses `x64` platform when arch == x64', function() {
+      opts.drivers.ie = {
+        baseURL: 'https://localhost',
+        version: '2.20.0',
+        arch: 'x64'
+      }
+
+      var actual = computeDownloadUrls(opts);
+      assert(actual.ie.indexOf('IEDriverServer_x64') > 0);
+    });
+
+    it('uses `major.minor` folder for `major.minor.patch` version', function() {
+      opts.drivers.ie = {
+        baseURL: 'https://localhost',
+        version: '2.20.1',
+        arch: 'x64'
+      }
+
+      var actual = computeDownloadUrls(opts);
+      assert(actual.ie.indexOf('/2.20/') > 0);
+      assert(actual.ie.indexOf('2.20.1.zip') > 0);
     });
   });
 });


### PR DESCRIPTION
There has been a number of PRs lately that improved how the URLs for binaries are generated. These helped us support older/newer versions of drivers where the structure of the filenames have been changed.

Since there is likely more of these types of changes necessary in the future, it is a good time to have some test cases in place to ensure that any future improvements support existing workflows as much as possible. This PR adds a non-exhaustive number of tests based on the conditionals that I found in the code.

NOTE: These tests do not verify that the module is returning valid URLs that will respond with the desired binary files. It is just testing that the URL is constructed how we expected.