### PR TITLE
Fix launching selenium 3.0-beta server

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -55,10 +55,7 @@ function start(opts, cb) {
     opts.javaPath = which.sync('java');
   }
 
-  var args = [
-    '-jar',
-    fsPaths.selenium.installPath
-  ];
+  var args = [];
 
   if (fsPaths.chrome) {
     args.push('-Dwebdriver.chrome.driver=' + fsPaths.chrome.installPath);
@@ -75,6 +72,9 @@ function start(opts, cb) {
   }
 
   args = args.concat(opts.seleniumArgs);
+
+  // Java requires properties to be set before the `-jar` in order to be consistently read.
+  args = args.concat(['-jar', fsPaths.selenium.installPath]);
 
   checkPathsExistence(getInstallPaths(fsPaths), function(err) {
     if (err) {


### PR DESCRIPTION
Selenium 3 changed how their command line arguments were parsed. Now they use the java standard of having properties set before the jar. See https://github.com/SeleniumHQ/selenium/issues/2566

```shell
java -Dwebdriver.chrome.driver=... -Dwebdriver.gecko.driver=...  -jar server.jar
```

---
Fixes https://github.com/vvo/selenium-standalone/issues/218