### PR TITLE
Fix launching with custom arguments

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -55,6 +55,17 @@ function start(opts, cb) {
     opts.javaPath = which.sync('java');
   }
 
+  /* Command to run selenium is build in the following order:
+      0) Java executable
+      1) System level properties
+      2) Jar binary
+      3) Selenium specific arguments
+
+     Example:
+       java -Dwebdriver.chrome.driver=./.selenium/chromedriver/2.22-x64-chromedriver \
+          -jar ./.selenium/selenium-server/2.53.1-server.jar \
+          -role hub
+   */
   var args = [];
 
   if (fsPaths.chrome) {
@@ -71,10 +82,9 @@ function start(opts, cb) {
     args.push('-Dwebdriver.gecko.driver=' + fsPaths.firefox.installPath);
   }
 
-  args = args.concat(opts.seleniumArgs);
-
-  // Java requires properties to be set before the `-jar` in order to be consistently read.
   args = args.concat(['-jar', fsPaths.selenium.installPath]);
+
+  args = args.concat(opts.seleniumArgs);
 
   checkPathsExistence(getInstallPaths(fsPaths), function(err) {
     if (err) {

--- a/test/programmatic.js
+++ b/test/programmatic.js
@@ -68,6 +68,15 @@ describe('programmatic use', function () {
     });
   });
 
+  it('should start with custom seleniumArgs', function(done) {
+    testStart(done, { seleniumArgs: ['-port', '12345'] }, function(cp) {
+      if (cp.spawnargs && !cp.spawnargs.some(containsChrome)) {
+        done(new Error('Chrome driver should be loaded'));
+        return false;
+      }
+    });
+  });
+
   it('should start with the given drivers', function(done) {
     testStart(done, { drivers: {} }, function(cp) {
       if (cp.spawnargs && cp.spawnargs.some(containsChrome)) {


### PR DESCRIPTION
```text
$ ./bin/selenium-standalone start -version=2.53.1 -- -port 5556
13:29:49.643 INFO - Launching a standalone Selenium Server
13:29:49.673 INFO - Java: Oracle Corporation 25.45-b02
13:29:49.673 INFO - OS: Mac OS X 10.10.5 x86_64
...
```

```text
$ ./bin/selenium-standalone start -version=3.0.0-beta2 -- -port 5556
13:27:34.467 INFO - Launching a standalone Selenium Server
13:27:34.499 INFO - Java: Oracle Corporation 25.45-b02
13:27:34.499 INFO - OS: Mac OS X 10.10.5 x86_64
...
```


---
Fixes #225 