### PR TITLE
Support for --config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ selenium-standalone start -- -role hub
 selenium-standalone start -- -role node -hub http://localhost:4444/grid/register
 selenium-standalone start -- -role node -hub http://localhost:4444/grid/register -port 5556
 
-# specify options in config file
+# If you have a complex configuration with numerous options or if you want to keep a clear configuration changes history,
+# you can specify the options in a configuration file :
 selenium-standalone install --config=/path/to/config.json
 selenium-standalone start --config=./config/seleniumConfig.js
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ selenium-standalone start --config=./config/seleniumConfig.js
 
 ```
 
-Config file can be a JSON file or a [module file](https://nodejs.org/api/modules.html#modules_file_modules) that exports options as an object :
+Config file can be a JSON file or a [module file](https://nodejs.org/api/modules.html#modules_file_modules) that exports options as an object:
 
 ```js
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -40,7 +40,24 @@ selenium-standalone start -- -role hub
 selenium-standalone start -- -role node -hub http://localhost:4444/grid/register
 selenium-standalone start -- -role node -hub http://localhost:4444/grid/register -port 5556
 
+# specify options in config file
+selenium-standalone install --config=/path/to/config.json
+selenium-standalone install --config=./config/seleniumConfig.js
 
+```
+
+Config file can be a JSON file or a [module file](https://nodejs.org/api/modules.html#modules_file_modules) that exports options as an object :
+
+```js
+module.exports = {
+  drivers: {
+    chrome: {
+      version: '2.23',
+      arch: process.arch,
+      baseURL: 'https://chromedriver.storage.googleapis.com'
+    },
+  },
+}
 ```
 
 ## Application Programming Interface (API)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ selenium-standalone start -- -role node -hub http://localhost:4444/grid/register
 
 # specify options in config file
 selenium-standalone install --config=/path/to/config.json
-selenium-standalone install --config=./config/seleniumConfig.js
+selenium-standalone start --config=./config/seleniumConfig.js
 
 ```
 

--- a/bin/selenium-standalone
+++ b/bin/selenium-standalone
@@ -8,25 +8,6 @@ var path = require('path');
 var selenium = require('../');
 var defaultConfig = require('../lib/default-config');
 
-function isAbsolutePosix(path) {
-  return path.charAt(0) === '/';
-}
-
-function isAbsoluteWin32(path) {
-  // https://github.com/nodejs/node/blob/b3fcc245fb25539909ef1d5eaa01dbf92e168633/lib/path.js#L56
-  var splitDeviceRe = /^([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/]+[^\\\/]+)?([\\\/])?([\s\S]*?)$/;
-  var result = splitDeviceRe.exec(path);
-  var device = result[1] || '';
-  var isUnc = Boolean(device && device.charAt(1) !== ':');
-
-  // UNC paths are always absolute
-  return Boolean(result[2] || isUnc);
-}
-
-function isAbsolute(path) {
-  return (process.platform === 'win32') ? isAbsoluteWin32(path) : isAbsolutePosix(path);
-}
-
 function parseCommandAndOptions(javaPath) {
   var argv = minimist(process.argv.slice(2), {
     string: ['version', 'drivers.chrome.version', 'drivers.ie.version', 'drivers.firefox.version']
@@ -58,9 +39,7 @@ function parseCommandAndOptions(javaPath) {
 
   if (argv.config) {
     try {
-      configFromFile = require(
-        isAbsolute(argv.config) ? argv.config : path.resolve(process.cwd(), argv.config)
-      );
+      configFromFile = require(path.resolve(process.cwd(), argv.config));
       if (typeof configFromFile !== 'object') {
         throw new Error('Config file does not exports an object');
       }

--- a/bin/selenium-standalone
+++ b/bin/selenium-standalone
@@ -3,41 +3,74 @@
 var minimist = require('minimist');
 var which = require('which');
 var merge = require('lodash').merge;
+var path = require('path');
 
 var selenium = require('../');
 var defaultConfig = require('../lib/default-config');
 
-which('java', function javaFound(err, javaPath) {
-  if (err) {
-    console.error('Could not find `java`, make sure it is installed in your $PATH');
-    return;
-  }
+function isAbsolutePosix(path) {
+  return path.charAt(0) === '/';
+}
 
+function isAbsoluteWin32(path) {
+  // https://github.com/nodejs/node/blob/b3fcc245fb25539909ef1d5eaa01dbf92e168633/lib/path.js#L56
+  var splitDeviceRe = /^([a-zA-Z]:|[\\\/]{2}[^\\\/]+[\\\/]+[^\\\/]+)?([\\\/])?([\s\S]*?)$/;
+  var result = splitDeviceRe.exec(path);
+  var device = result[1] || '';
+  var isUnc = Boolean(device && device.charAt(1) !== ':');
+
+  // UNC paths are always absolute
+  return Boolean(result[2] || isUnc);
+}
+
+function isAbsolute(path) {
+  return (process.platform === 'win32') ? isAbsoluteWin32(path) : isAbsolutePosix(path);
+}
+
+function parseCommandAndOptions(javaPath) {
   var argv = minimist(process.argv.slice(2), {
     string: ['version', 'drivers.chrome.version', 'drivers.ie.version', 'drivers.firefox.version']
   });
 
   var action = argv._[0];
 
+  if (!action) {
+    throw new Error('No action provided');
+  }
   if (action !== 'install' && action !== 'start') {
-    console.log('Usage: selenium-standalone install or selenium-standalone start');
-    return;
+    throw new Error('Invalid action "'+ action + ' (Valid actions are [' + Object.keys(actions).join(', ') + '])');
   }
 
   // everything after `selenium-standalone install [options] --` will be in argv._
   var seleniumArgs = argv._.slice(1);
 
-  // build a new map removing `_` from argv
+  // build a new map removing `_` and --config from argv
   var options = Object.keys(argv).reduce(function(prev, cur) {
-    if (cur !== '_') {
+    if ((cur !== '_') && (cur !== 'config')) {
       prev[cur] = argv[cur];
     }
 
     return prev;
   }, {});
 
-  // Merge in default options
-  options = merge({}, defaultConfig, options);
+  // If a config file was specified, load it
+  var configFromFile = {};
+
+  if (argv.config) {
+    try {
+      configFromFile = require(
+        isAbsolute(argv.config) ? argv.config : path.resolve(process.cwd(), argv.config)
+      );
+      if (typeof configFromFile !== 'object') {
+        throw new Error('Config file does not exports an object');
+      }
+    } catch(err) {
+      throw new Error('Error parsing config file : ' + (err.message || err));
+    }
+  }
+
+  // Merge default options, options from config file then command line options
+  options = merge({}, defaultConfig, configFromFile, options);
 
   options.seleniumArgs = seleniumArgs;
   options.spawnOptions = {
@@ -47,8 +80,8 @@ which('java', function javaFound(err, javaPath) {
   options.logger = options.silent ? null : console.log;
   options.javaPath = javaPath;
 
-  actions[action](options);
-});
+  return [action, options];
+}
 
 var actions = {
   start: function(options) {
@@ -113,3 +146,24 @@ var actions = {
     }
   }
 };
+
+// Export the command line parsing function for tests.
+module.exports = parseCommandAndOptions;
+
+if (!process.env || !process.env.NODE_ENV || (process.env.NODE_ENV !== 'test-cli-parameters')) {
+  which('java', function javaFound(err, javaPath) {
+    var params;
+
+    try {
+      if (err) {
+        throw err;
+      }
+      params = parseCommandAndOptions(javaPath);
+    } catch (err) {
+      process.stderr.write((err.message || err) + "\n");
+      process.stderr.write("Usage: selenium-standalone action [options]\n");
+      process.exit(255);
+    }
+    actions[params[0]](params[1]);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "yauzl": "^2.5.0"
   },
   "devDependencies": {
+    "chai": "3.5.0",
     "mocha": "2.1.0"
   }
 }

--- a/test/cli-parameters.js
+++ b/test/cli-parameters.js
@@ -1,0 +1,173 @@
+var path = require('path');
+var chai = require('chai');
+var expect = chai.expect;
+var parseCommandAndOptions;
+var processNodeEnv;
+
+/**
+ * Builds a valid ARGV array with passed arguments.
+ */
+function buildArgv(args) {
+  var argv = ['/somewhere/node', '/somewhere/selenium-standalone'];
+
+  if (args) {
+    argv = argv.concat(args);
+  }
+  return argv;
+}
+
+/**
+ * Tests for `selenium-standalone` command parameters parsing.
+ */
+describe('`selenium-standalone` command parameters', function() {
+  // Allow tests to mock `process.platform`
+  before(function() {
+    this.originalArgv = Object.getOwnPropertyDescriptor(process, 'argv');
+  });
+  after(function() {
+    Object.defineProperty(process, 'argv', this.originalArgv);
+  });
+
+  // Ensure that any internal state of the module is clean for each test
+  beforeEach(function() {
+    if (process.env) {
+      processNodeEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'test-cli-parameters';
+    } else {
+      process.env = { NODE_ENV: 'test-cli-parameters' };
+    }
+    parseCommandAndOptions = require('../bin/selenium-standalone').bind(null, '/path/to/java');
+  });
+  afterEach(function() {
+    delete require.cache[require.resolve('../bin/selenium-standalone')];
+    if (processNodeEnv) {
+      process.env.NODE_ENV = processNodeEnv;
+    } else {
+      delete process.env.NODE_ENV;
+    }
+  });
+
+  describe('action', function() {
+    it('is required', function() {
+      process.argv = buildArgv();
+      expect(parseCommandAndOptions)
+        .to.throw(/^No action provided$/);
+    });
+
+    it('only accepts valid values', function() {
+      process.argv = buildArgv(['test']);
+      expect(parseCommandAndOptions).to.throw(/^Invalid action /);
+      process.argv = buildArgv(['install']);
+      expect(parseCommandAndOptions).to.not.throw();
+      process.argv = buildArgv(['start']);
+      expect(parseCommandAndOptions).to.not.throw();
+    });
+  });
+
+  describe('arguments', function() {
+    it('are correctly parsed', function() {
+      process.argv = buildArgv([
+        'install',
+        '--test=1',
+        '-a', 'ok',
+        '-h'
+      ]);
+      var parsed = parseCommandAndOptions();
+
+      expect(parsed[1].test).to.be.equal(1);
+      expect(parsed[1].a).to.be.equal('ok');
+      expect(parsed[1].h).to.be.true;
+    });
+
+    it('are correctly passed unparsed to selenium when after --', function() {
+      process.argv = buildArgv([
+        'install',
+        '--test=1',
+        '--',
+        '--test=1',
+        '-a', 'ok',
+        '-h',
+      ]);
+      var parsed = parseCommandAndOptions();
+
+      expect(parsed[1].test).to.be.equal(1);
+      expect(parsed[1].a).to.be.undefined;
+      expect(parsed[1].seleniumArgs).to.deep.equal(['--test=1', '-a', 'ok', '-h']);
+    });
+
+    it('takes default values when not specified', function() {
+      process.argv = buildArgv(['install']);
+      var parsed1 = parseCommandAndOptions('/somewhere');
+      var defaultValues = require('../lib/default-config');
+
+      Object.keys(defaultValues).forEach(function(key) {
+        expect(parsed1[1][key]).to.deep.equal(defaultValues[key]);
+      });
+
+      process.argv = buildArgv(['install', '--drivers.chrome.version=42']);
+      var parsed2 = parseCommandAndOptions('/somewhere');
+
+      expect(parsed2[1].drivers.chrome.version).to.be.equal('42');
+      expect(parsed2[1].drivers.chrome.baseURL)
+        .to.be.equal(defaultValues.drivers.chrome.baseURL);
+    });
+
+    it('are correctly parsed from a JSON config file', function() {
+      process.argv = buildArgv([
+        'install',
+        '--config=' + path.join(__dirname, 'fixtures', 'config.valid.json'),
+      ]);
+      var parsed = parseCommandAndOptions('/somewhere');
+
+      expect(parsed[1].version).to.be.equal('42');
+      expect(parsed[1].drivers.ie.version).to.be.equal(42);
+      expect(parsed[1].drivers.ie.baseURL).to.be.equal('http://www.google.fr');
+    });
+
+    it('are correctly parsed from a JS module config file', function() {
+      process.argv = buildArgv([
+        'install',
+        '--config=' + path.join(__dirname, 'fixtures', 'config.valid.js'),
+      ]);
+      var parsed = parseCommandAndOptions('/somewhere');
+
+      expect(parsed[1].version).to.be.equal('42');
+      expect(parsed[1].drivers.ie.version).to.be.equal(42);
+      expect(parsed[1].drivers.ie.baseURL).to.be.equal('http://www.google.fr');
+    });
+
+    it('throws if config file is invalid', function() {
+      process.argv = buildArgv([
+        'install',
+        '--config=' + path.join(__dirname, 'fixtures', 'config.invalid.json'),
+      ]);
+
+      expect(parseCommandAndOptions).to.throw(/^Error parsing config file :/);
+    });
+
+    it('throws if config file is not an object', function() {
+      process.argv = buildArgv([
+        'install',
+        '--config=' + path.join(__dirname, 'fixtures', 'config.invalid.js'),
+      ]);
+
+      expect(parseCommandAndOptions).to.throw(/^Error parsing config file : Config file does not exports an object$/);
+    });
+
+    it('respects the precedence order : command line > config file > default', function() {
+      var defaultValues = require('../lib/default-config');
+
+      process.argv = buildArgv([
+        'install',
+        '--config=' + path.join(__dirname, 'fixtures', 'config.valid.js'),
+        '--drivers.ie.version=43',
+      ]);
+
+      var parsed = parseCommandAndOptions('/somewhere');
+
+      expect(parsed[1].version).to.be.equal('42');
+      expect(parsed[1].drivers.ie.arch).to.be.equal(defaultValues.drivers.ie.arch);
+      expect(parsed[1].drivers.ie.version).to.be.equal('43');
+    });
+  });
+});

--- a/test/fixtures/config.invalid.js
+++ b/test/fixtures/config.invalid.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/test/fixtures/config.invalid.json
+++ b/test/fixtures/config.invalid.json
@@ -1,0 +1,9 @@
+{
+  "version": "42",
+  "drivers": {
+    "ie": {
+      "version": 42,
+      "baseURL": "http://www.google.fr",
+    }
+  }
+}

--- a/test/fixtures/config.valid.js
+++ b/test/fixtures/config.valid.js
@@ -1,0 +1,9 @@
+module.exports = {
+  version: "42",
+  drivers: {
+    ie: {
+      version: 42,
+      baseURL: 'http://www.google.fr',
+    }
+  }
+};

--- a/test/fixtures/config.valid.json
+++ b/test/fixtures/config.valid.json
@@ -1,0 +1,9 @@
+{
+  "version": "42",
+  "drivers": {
+    "ie": {
+      "version": 42,
+      "baseURL": "http://www.google.fr"
+    }
+  }
+}


### PR DESCRIPTION
Support for the `--config=<path>` option for specifying a config file instead of command line arguments (#230) 
Included unit tests (#238) requested by @stephenash 