### PR TITLE
Bump request and mocha to avoid npm warnings

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -98,16 +98,16 @@ function install(opts, cb) {
   });
 
   function onlyInstallMissingFiles(opts, cb) {
-    async.series([
+    async.waterfall([
       checksum.bind(null, opts.to),
-      etag.bind(null, opts.from, requestOpts)
-    ], function (error, results) {
+      isUpToDate.bind(null, opts.from, requestOpts)
+    ], function (error, isLatest) {
       if (error) {
         return cb(error);
       }
 
       // File already exists. Prevent download/installation.
-      if (results[0] === results[1]) {
+      if (isLatest) {
         logger('---');
         logger('File from ' + opts.from + ' has already been downloaded');
         expectedRequests -= 1;
@@ -391,7 +391,7 @@ function logInstallSummary(logger, paths, urls) {
 
 function checksum (filepath, cb) {
   if (!fs.existsSync(filepath)) {
-    return cb();
+    return cb(null, null);
   }
 
   var hash = crypto.createHash('md5');
@@ -414,25 +414,31 @@ function unquote (str, quoteChar) {
   return str;
 }
 
-function etag (url, requestOpts, cb) {
-  var verb = 'head';
-
-  var parsedUrl = require('url').parse(url);
-  if (parsedUrl.host === 'github.com') {
-    verb = 'get';
+function isUpToDate (url, requestOpts, hash, cb) {
+  if (!hash) {
+    return cb(null, false);
   }
 
-  var req = request[verb](url, requestOpts)
+  var query = Object.assign({}, requestOpts, {
+    url: url,
+    headers: {
+      'If-None-Match': '"' + hash + '"'
+    }
+  });
+
+  var req = request.get(query);
   req.on('response', function (res) {
-    if (verb === 'get') {
-      req.abort();
+    req.abort();
+
+    if (res.statusCode === 304) {
+      return cb(null, true);
     }
 
     if (res.statusCode !== 200) {
       return cb(new Error('Could not request headers from ' + url + ': ', res.statusCodestatusCode));
     }
 
-    cb(null, unquote(res.headers.etag));
+    cb(null, false);
   }).once('error', function (err) {
     cb(new Error('Could not request headers from ' + url + ': ' + err));
   });

--- a/lib/install.js
+++ b/lib/install.js
@@ -415,7 +415,18 @@ function unquote (str, quoteChar) {
 }
 
 function etag (url, requestOpts, cb) {
-  request.head(url, requestOpts).on('response', function (res) {
+  var verb = 'head';
+
+  if (url.indexOf('https://github.com') >= 0) {
+    verb = 'get';
+  }
+
+  var req = request[verb](url, requestOpts)
+  req.on('response', function (res) {
+    if (verb === 'get') {
+      req.abort();
+    }
+
     if (res.statusCode !== 200) {
       return cb(new Error('Could not request headers from ' + url + ': ', res.statusCodestatusCode));
     }

--- a/lib/install.js
+++ b/lib/install.js
@@ -417,7 +417,8 @@ function unquote (str, quoteChar) {
 function etag (url, requestOpts, cb) {
   var verb = 'head';
 
-  if (url.indexOf('https://github.com') >= 0) {
+  var parsedUrl = require('url').parse(url);
+  if (parsedUrl.host === 'github.com') {
     verb = 'get';
   }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "minimist": "1.1.0",
     "mkdirp": "0.5.0",
     "progress": "1.1.8",
-    "request": "2.51.0",
+    "request": "2.79.0",
     "tar-stream": "1.5.2",
     "urijs": "1.16.1",
     "which": "1.1.1",
@@ -35,6 +35,6 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "mocha": "2.1.0"
+    "mocha": "3.2.0"
   }
 }


### PR DESCRIPTION
Hi,

Just a quick bump of a few dependencies that were causing npm warnings on recent node versions.
Had to add a little code for request since its [version 2.59.0](https://github.com/request/request/blob/master/CHANGELOG.md#v2590-20150720) fixed HEAD behavior, which is actually rejected by S3, so a GET request is needed.
I have very little experience with this module so maybe my indexOf strategy is not the best, but it works for the default case.