### PR TITLE
Object.assign n/a in node 0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 sudo: false
 
 language: node_js
-node_js: stable
+node_js:
+  - stable
+  - 6
+  - 5
+  - 4
+  - 0.12
+

--- a/lib/install.js
+++ b/lib/install.js
@@ -419,7 +419,7 @@ function isUpToDate (url, requestOpts, hash, cb) {
     return cb(null, false);
   }
 
-  var query = Object.assign({}, requestOpts, {
+  var query = merge({}, requestOpts, {
     url: url,
     headers: {
       'If-None-Match': '"' + hash + '"'


### PR DESCRIPTION
Previous PR added `Object.assign`, which is not available in node <4

I added node.js versions travis config to be sure to cover this in next PRs