### PR TITLE
ChromeDriver bump.

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,7 +3,7 @@ module.exports = {
   version: '3.0.1',
   drivers: {
     chrome: {
-      version: '2.27',
+      version: '2.28',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
Bumping to 2.28, fixes automation extension bug in Chrome. 

See:
https://bugs.chromium.org/p/chromedriver/issues/detail?id=1625&can=1&q=screenshot&colspec=ID%20Status%20Pri%20Owner%20Summary