### PR TITLE
update Selenium and Geckodriver versions

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   baseURL: 'https://selenium-release.storage.googleapis.com',
-  version: '3.0.1',
+  version: '3.3.1',
   drivers: {
     chrome: {
       version: '2.28',
@@ -13,7 +13,7 @@ module.exports = {
       baseURL: 'https://selenium-release.storage.googleapis.com'
     },
     firefox: {
-      version: '0.13.0',
+      version: '0.15.0',
       arch: process.arch,
       baseURL: 'https://github.com/mozilla/geckodriver/releases/download'
     }

--- a/test/default-downloads-test.js
+++ b/test/default-downloads-test.js
@@ -196,21 +196,6 @@ describe('default-downloads', function() {
         });
       });
 
-      it('ia32 download exists', function(done) {
-        opts = merge(opts, {
-          drivers: {
-            firefox: {
-              arch: 'ia32'
-            }
-          }
-        });
-
-        computedUrls = computeDownloadUrls(opts);
-
-        assert(computedUrls.firefox.indexOf('linux32') > 0);
-        doesDownloadExist(computedUrls.firefox, done);
-      });
-
       it('x64 download exists', function(done) {
         opts = merge(opts, {
           drivers: {


### PR DESCRIPTION
Update version to the latest version

Reason
Latest gecko is dependent on latest selenium driver. The 32-bit linux version of Geckodriver 0.15.0 is missing. See: https://github.com/mozilla/geckodriver/releases. 