### PR TITLE
Update chromedriver to default to 2.30

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 6.5.0 (2017-06-08)
+
+* Update default chromedriver to 2.30
+
 # 6.4.1 (2017-04-24)
 
 * Fix seleniumArgs handling in config file

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Config file can be a JSON file or a [module file](https://nodejs.org/api/modules
 module.exports = {
   drivers: {
     chrome: {
-      version: '2.27',
+      version: '2.30',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
@@ -82,7 +82,7 @@ selenium.install({
     chrome: {
       // check for more recent versions of chrome driver here:
       // https://chromedriver.storage.googleapis.com/index.html
-      version: '2.27',
+      version: '2.30',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
@@ -115,7 +115,7 @@ Here are the current defaults:
 ```js
 {
   chrome: {
-    version: '2.27',
+    version: '2.30',
     arch: process.arch,
     baseURL: 'https://chromedriver.storage.googleapis.com'
   },

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,7 +3,7 @@ module.exports = {
   version: '3.4.0',
   drivers: {
     chrome: {
-      version: '2.29',
+      version: '2.30',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selenium-standalone",
-  "version": "6.4.1",
+  "version": "6.5.0",
   "description": "installs a `selenium-standalone` command line to install and start a standalone selenium server",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Chromium [released chromedriver 2.30](https://sites.google.com/a/chromium.org/chromedriver/downloads)  today

Defaulting **chromedriver** to **2.30** will fix issues when trying to resize the browser when using **Chrome headless**.

The following APIs have been moved from being an extension to being part of the Dev Tools
https://chromedevtools.github.io/devtools-protocol/tot/Browser/#method-setWindowBounds

As chrome headless does not allow the use of extensions then resizing the browser fails with any version lower than 2.30.

Binaries available here:
https://chromedriver.storage.googleapis.com/index.html?path=2.30/