### PR TITLE
Update default chromedriver to 2.31

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+# 6.6.0 (2017-07-23)
+* Update default chromedriver to 2.31
+
 # 6.5.0 (2017-06-08)
 
 * Ability to install Microsoft Edge driver (#284)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Config file can be a JSON file or a [module file](https://nodejs.org/api/modules
 module.exports = {
   drivers: {
     chrome: {
-      version: '2.30',
+      version: '2.31',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
@@ -82,7 +82,7 @@ selenium.install({
     chrome: {
       // check for more recent versions of chrome driver here:
       // https://chromedriver.storage.googleapis.com/index.html
-      version: '2.30',
+      version: '2.31',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
@@ -115,7 +115,7 @@ Here are the current defaults:
 ```js
 {
   chrome: {
-    version: '2.30',
+    version: '2.31',
     arch: process.arch,
     baseURL: 'https://chromedriver.storage.googleapis.com'
   },

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,7 +3,7 @@ module.exports = {
   version: '3.4.0',
   drivers: {
     chrome: {
-      version: '2.30',
+      version: '2.31',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selenium-standalone",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "description": "installs a `selenium-standalone` command line to install and start a standalone selenium server",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Chromium [released chromedriver 2.31](https://sites.google.com/a/chromium.org/chromedriver/downloads) yesterday

Defaulting **chromedriver** to **2.31** will fix issues when trying to use the sendKeys API (input keystrokes to the browser) when using **Chrome headless**.

Details of the fix can be found in this bug tracker
https://bugs.chromium.org/p/chromedriver/issues/detail?id=1772
With merge request here
https://codereview.chromium.org/2952383002


Binaries available here:
https://chromedriver.storage.googleapis.com/index.html?path=2.31/