### PR TITLE
Add correct urandom devnode path when on linux

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -77,6 +77,10 @@ function start(opts, cb) {
     args.push('-Dwebdriver.chrome.driver=' + fsPaths.chrome.installPath);
   }
 
+  if (process.platform === 'linux') {
+    args.push('-Djava.security.egd=file:///dev/urandom');
+  }
+  
   if (process.platform === 'win32' && fsPaths.ie) {
     args.push('-Dwebdriver.ie.driver=' + fsPaths.ie.installPath);
   } else {


### PR DESCRIPTION
When on Linux (in my case, Debian) Selenium won't start because it waits for entropy from `/dev/random` (which can block and depletes the entropy pool). Pointing it to `/dev/urandom` fixes this.