### PR TITLE
Fix selenium server status check URL when passing node config file

### DIFF
--- a/lib/get-selenium-status-url.js
+++ b/lib/get-selenium-status-url.js
@@ -1,26 +1,74 @@
 var URI = require('urijs');
+var fs = require('fs');
+
 var PROCESS_TYPES = exports.PROCESS_TYPES = {
   STANDALONE: 0,
   GRID_HUB: 1,
   GRID_NODE: 2
 };
 
-exports.getRunningProcessType = function(seleniumArgs) {
-  var roleArg = seleniumArgs.indexOf('-role');
-  var role = (roleArg !== -1) ? seleniumArgs[roleArg + 1] : undefined;
-
-  if (roleArg === -1) return PROCESS_TYPES.STANDALONE;
+function parseRole(role) {
+  if (!role) return PROCESS_TYPES.STANDALONE;
   else if (role === 'hub') return PROCESS_TYPES.GRID_HUB;
   else if (role === 'node') return PROCESS_TYPES.GRID_NODE;
   else return undefined;
 }
 
+function getDefaultPort(processType) {
+  switch (processType) {
+    case PROCESS_TYPES.STANDALONE:
+    case PROCESS_TYPES.GRID_HUB:
+      return 4444;
+      break;
+    case PROCESS_TYPES.GRID_NODE:
+      return 5555;
+  }
+}
+
+exports.getRunningProcessType = function(seleniumArgs) {
+  var roleArg = seleniumArgs.indexOf('-role');
+  var role = (roleArg !== -1) ? seleniumArgs[roleArg + 1] : undefined;
+
+  return parseRole(role);
+}
+
 exports.getSeleniumStatusUrl = function(seleniumArgs) {
-  var processType = this.getRunningProcessType(seleniumArgs);
-  var portArg = seleniumArgs.indexOf('-port');
-  var port = (portArg !== -1) ? seleniumArgs[portArg + 1] : undefined;
-  var hostArg = seleniumArgs.indexOf('-host');
-  var host = (hostArg !== -1) ? seleniumArgs[hostArg + 1] : 'localhost';
+  var host = 'localhost',
+      port,
+      statusURI,
+      processType,
+      nodeConfigArg = seleniumArgs.indexOf('-nodeConfig'),
+      config,
+      portArg = seleniumArgs.indexOf('-port'),
+      hostArg = seleniumArgs.indexOf('-host'),
+      processType = this.getRunningProcessType(seleniumArgs);
+
+  // If node config path is pass via -nodeConfig, we have to take settings from there,
+  // and override them with possible command line options, as later ones have higher priority
+  if (nodeConfigArg !== -1) {
+    // Load node configuration and parse it
+    config = JSON.parse(fs.readFileSync(seleniumArgs[nodeConfigArg + 1], 'utf8'));
+    if (config['host']) {
+      host = config['host'];
+    }
+    if (config['port']) {
+      port = config['port'];
+    }
+
+    // If processType is defined, then it was specified via command line options,
+    // we ignore the value defined in the config file, otherwise we take it from the file
+    if (!processType && config['role']) {
+      processType = parseRole(config['role']);
+    }
+  }
+
+  // Overrode port and host if they were specified
+  if (portArg !== - 1) {
+    port = seleniumArgs[portArg + 1];
+  }
+  if (hostArg !== - 1) {
+    host = seleniumArgs[hostArg + 1];
+  }
 
   var statusURI = new URI('http://' + host);
   var nodeStatusAPIPath = '/wd/hub/status';
@@ -28,25 +76,19 @@ exports.getSeleniumStatusUrl = function(seleniumArgs) {
 
   switch (processType) {
     case PROCESS_TYPES.STANDALONE:
-      statusURI.port(4444);
       statusURI.path(nodeStatusAPIPath);
       break;
     case PROCESS_TYPES.GRID_HUB:
-      statusURI.port(4444);
       statusURI.path(hubStatusAPIPath);
       break;
     case PROCESS_TYPES.GRID_NODE:
-      statusURI.port(5555);
       statusURI.path(nodeStatusAPIPath);
       break;
     default:
       throw 'ERROR: Trying to run selenium in an unknown way.';
   }
 
-  // Running with a non-default port
-  if (portArg !== -1) {
-    statusURI.port(seleniumArgs[portArg + 1]);
-  }
-
+  // Running non-default port if it was specified or default one if it was not
+  statusURI.port(port || getDefaultPort(processType));
   return statusURI.toString();
 }

--- a/test/fixtures/config.node.json
+++ b/test/fixtures/config.node.json
@@ -1,0 +1,5 @@
+{
+  "hub": "http://bar",
+  "port": 123,
+  "host": "foo"
+}

--- a/test/get-selenium-hub-test.js
+++ b/test/get-selenium-hub-test.js
@@ -1,9 +1,9 @@
+var path = require('path');
 var assert = require("assert");
 var statusUrl = require('../lib/get-selenium-status-url');
 
 var nodeStatusAPIPath = '/wd/hub/status';
 var hubStatusAPIPath = '/grid/api/hub';
-
 describe('getRunningProcessType', function () {
   var tests = [
     // Started as a standalone Selenium Server
@@ -47,7 +47,11 @@ describe('getSeleniumStatusUrl', function () {
               {args: ['-role', 'node', '-port', '7777'], expectedUrl: 'localhost:7777' + nodeStatusAPIPath},
               {args: ['-role', 'node', '-host', 'alias', '-port', '7777'], expectedUrl: 'alias:7777' + nodeStatusAPIPath},
               {args: ['-role', 'node', '-hub', 'https://foo/wd/register'], expectedUrl: 'localhost:5555' + nodeStatusAPIPath},
-              {args: ['-role', 'node', '-hub', 'https://foo:6666/wd/register', '-port', '7777'], expectedUrl: 'localhost:7777' + nodeStatusAPIPath}
+              {args: ['-role', 'node', '-hub', 'https://foo:6666/wd/register', '-port', '7777'], expectedUrl: 'localhost:7777' + nodeStatusAPIPath},
+
+              {args: ['-role', 'node', '-nodeConfig', path.join(__dirname, 'fixtures', 'config.node.json')], expectedUrl: 'foo:123' + nodeStatusAPIPath},
+              {args: ['-role', 'node', '-host', 'alias', '-nodeConfig', path.join(__dirname, 'fixtures', 'config.node.json')], expectedUrl: 'alias:123' + nodeStatusAPIPath},
+              {args: ['-role', 'node', '-host', 'alias', '-port', '7777', '-nodeConfig', path.join(__dirname, 'fixtures', 'config.node.json')], expectedUrl: 'alias:7777' + nodeStatusAPIPath},
             ];
 
   var testWithData = function (dataItem) {


### PR DESCRIPTION
As mentioned in selenium server documentation it is possible to pass the node configuration options via -nodeConfig parameter (https://github.com/SeleniumHQ/selenium/wiki/Grid2#configuring-the-nodes-by-json). 
Unfortunately selenium-standalone didn't had support for that parameter and was constructing the status check URL incorrectly. Therefore node was stopping after several failed attempts.

I changed selenium status page URL construction to take into account host, port parameters defined in node config file and added tests.