### PR TITLE
adding the ability to install single driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ selenium-standalone install --drivers.chrome.version=2.15 --drivers.chrome.baseU
 # choose ie driver architecture
 selenium-standalone start --drivers.ie.arch=ia32 --drivers.ie.baseURL=https://selenium-release.storage.googleapis.com
 
+# install a single driver within the default list (chrome, ie, edge, firefox)
+selenium-standalone install --singleDriverInstall=chrome
+
 # specify hub and nodes to setup your own selenium grid
 selenium-standalone start -- -role hub
 selenium-standalone start -- -role node -hub http://localhost:4444/grid/register

--- a/lib/install.js
+++ b/lib/install.js
@@ -50,6 +50,13 @@ function install(opts, cb) {
     opts.drivers = defaultConfig.drivers;
   }
 
+  if (opts.singleDriverInstall) {
+    if(defaultConfig.drivers[opts.singleDriverInstall]) {
+      opts.drivers = {};
+      opts.drivers[opts.singleDriverInstall] = defaultConfig.drivers[opts.singleDriverInstall];
+    }
+  }
+
   if (process.platform !== 'win32') {
     delete opts.drivers.ie;
     delete opts.drivers.edge;


### PR DESCRIPTION
Our build fails given at times it's unable to download microsoft edge driver given the url seems to be flaky at times. There are solutions out there that suggest to change our network configuration, but given we only use chrome, it sounds about right not to install all drivers if the only one we want is chrome...