### PR TITLE
Update driver and selenium versions

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,14 +1,14 @@
 module.exports = {
   baseURL: 'https://selenium-release.storage.googleapis.com',
-  version: '3.7.1',
+  version: '3.8.1',
   drivers: {
     chrome: {
-      version: '2.33',
+      version: '2.35',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
     ie: {
-      version: '3.7.0',
+      version: '3.8.0',
       arch: process.arch,
       baseURL: 'https://selenium-release.storage.googleapis.com'
     },

--- a/test/default-downloads-test.js
+++ b/test/default-downloads-test.js
@@ -129,21 +129,6 @@ describe('default-downloads', function() {
         });
       });
 
-      it('ia32 download exists', function(done) {
-        opts = merge(opts, {
-          drivers: {
-            chrome: {
-              arch: 'ia32'
-            }
-          }
-        });
-
-        computedUrls = computeDownloadUrls(opts);
-
-        assert(computedUrls.chrome.indexOf('linux32') > 0);
-        doesDownloadExist(computedUrls.chrome, done);
-      });
-
       it('x64 download exists', function(done) {
         opts = merge(opts, {
           drivers: {


### PR DESCRIPTION
update the selenium and webdriver versions to "current"
this obsoletes pull #334 as this also update chromedriver

Also, remove test for chromedriver ia32 as it is no longer being built by google