### PR TITLE
Remove ia32 linux chromedriver test

### DIFF
--- a/test/default-downloads-test.js
+++ b/test/default-downloads-test.js
@@ -129,21 +129,6 @@ describe('default-downloads', function() {
         });
       });
 
-      it('ia32 download exists', function(done) {
-        opts = merge(opts, {
-          drivers: {
-            chrome: {
-              arch: 'ia32'
-            }
-          }
-        });
-
-        computedUrls = computeDownloadUrls(opts);
-
-        assert(computedUrls.chrome.indexOf('linux32') > 0);
-        doesDownloadExist(computedUrls.chrome, done);
-      });
-
       it('x64 download exists', function(done) {
         opts = merge(opts, {
           drivers: {


### PR DESCRIPTION
Remove ia32 linux chromedriver test as it is no longer supported by google

https://groups.google.com/forum/#!msg/chromedriver-users/JZUYvp_xr60/pyTRBxv1CwAJ