### PR TITLE
Update chromedriver to 2.36 and updates for linux 32

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -55,7 +55,7 @@ function computeDownloadUrls(opts, askedOpts) {
       urls.chrome,
       opts.drivers.chrome.baseURL,
       opts.drivers.chrome.version,
-      getChromeDriverPlatform(opts.drivers.chrome.arch)
+      getChromeDriverArchitecture(opts.drivers.chrome.version, opts.drivers.chrome.arch)
     );
   }
   if (opts.drivers.ie) {
@@ -80,14 +80,15 @@ function computeDownloadUrls(opts, askedOpts) {
   if (opts.drivers.edge) {
     downloadUrls.edge = getEdgeDriverUrl(opts.drivers.edge.version);
   }
+
   return downloadUrls;
 }
 
-function getChromeDriverPlatform(wantedArchitecture) {
+function getChromeDriverArchitecture(version, wantedArchitecture) {
   var platform;
 
   if (process.platform === 'linux') {
-    platform = 'linux' + (wantedArchitecture === 'x64' ? '64' : '32');
+    platform = getLinuxChromeDriverArchitecture(version, wantedArchitecture);
   } else if (process.platform === 'darwin') {
     if (mac32) {
       platform = 'mac32';
@@ -170,6 +171,15 @@ function getFirefoxDriverArchitecture(version, wantedArchitecture) {
     default :
       throw new Error('No Firefox driver is available for platform "' + process.platform + '"');
   }
+}
+
+function getLinuxChromeDriverArchitecture(version, wantedArchitecture) {
+  // Since 2.34, chromdriver support was dropped for linux 32
+  if(compareVersions(version, '2.34') >= 0 && wantedArchitecture !== 'x64') {
+    throw new Error('Only x64 architecture is available for chromdriver >= 2.34')
+  }
+
+  return 'linux' + (wantedArchitecture === 'x64' ? '64' : '32');
 }
 
 function getLinuxFirefoxDriverArchitecture(version, extension, wantedArchitecture) {

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,7 +3,7 @@ module.exports = {
   version: '3.8.1',
   drivers: {
     chrome: {
-      version: '2.33',
+      version: '2.36',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -78,7 +78,7 @@ describe('compute-download-urls', function() {
         });
       });
 
-      it('x32', function() {
+      it('x32 for versions < 2.34', function() {
         opts.drivers.chrome = {
           baseURL: 'https://localhost',
           version: '2.0',

--- a/test/default-downloads-test.js
+++ b/test/default-downloads-test.js
@@ -129,20 +129,7 @@ describe('default-downloads', function() {
         });
       });
 
-      it('ia32 download exists', function(done) {
-        opts = merge(opts, {
-          drivers: {
-            chrome: {
-              arch: 'ia32'
-            }
-          }
-        });
-
-        computedUrls = computeDownloadUrls(opts);
-
-        assert(computedUrls.chrome.indexOf('linux32') > 0);
-        doesDownloadExist(computedUrls.chrome, done);
-      });
+      // No x32 for latest chromedriver on linux
 
       it('x64 download exists', function(done) {
         opts = merge(opts, {


### PR DESCRIPTION
Updates chromedriver to 2.36.

Chromedriver doesn't support linux 32 after 2.33 so this updates the tests and throws an error for linux 32 > chromedirver 2.33.