### PR TITLE
Update requests dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
   - TRAVIS_NODE_VERSION="stable"
   - TRAVIS_NODE_VERSION=5
   - TRAVIS_NODE_VERSION=4
-  - TRAVIS_NODE_VERSION=0.12
-  
+
 branches:
   only:
     - "master"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "progress": "2.0.0",
-    "request": "2.79.0",
+    "request": "2.85.0",
     "tar-stream": "1.5.2",
     "urijs": "^1.18.4",
     "which": "^1.2.12",


### PR DESCRIPTION
It seems to be failing because of node 0.12 

This PR fixes a security vulnerability found in the hoek module before version 4.2.1

node 0.12 is no more maintained since 2016-12-31  : https://github.com/nodejs/Release#release-schedule

I suggest to drop support for it.