### PR TITLE
Updated to the latest Geckodriver that works with Firefox 66.0.1

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -13,7 +13,7 @@ module.exports = {
       baseURL: 'https://selenium-release.storage.googleapis.com'
     },
     firefox: {
-      version: '0.20.0',
+      version: '0.20.1',
       arch: process.arch,
       baseURL: 'https://github.com/mozilla/geckodriver/releases/download'
     },


### PR DESCRIPTION
Geckodriver 0.20.0 + Firefox 66.0.1 fails when attempting to click on an element which is visible in page but has `elem.getBoundingClientRect().height === 0`. I tested this with `wdio` on `document.body`

Geckodriver 0.20.1 + Firefox 66.0.1 works

Example of page in Firefox that reports height 0 on `document.body`:
<img width="804" alt="screen shot 2018-05-25 at 11 37 57" src="https://user-images.githubusercontent.com/1106849/40534919-35894088-6010-11e8-966a-d89bf62de269.png">


Q: @vvo have you ever considered having some e2e tests of browser quirks in different Browser + Webdriver combinations?