### PR TITLE
fix(install): prefer the user config rather that the default one

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -51,9 +51,10 @@ function install(opts, cb) {
   }
 
   if (opts.singleDriverInstall) {
-    if(defaultConfig.drivers[opts.singleDriverInstall]) {
+    var singleDriver = opts.drivers[opts.singleDriverInstall];
+    if(singleDriver) {
       opts.drivers = {};
-      opts.drivers[opts.singleDriverInstall] = defaultConfig.drivers[opts.singleDriverInstall];
+      opts.drivers[opts.singleDriverInstall] = singleDriver;
     }
   }
 


### PR DESCRIPTION
When using 

```sh
selenium-standalone install --version=3.6.0 --baseURL=http://my.mirror.com/selenium-server --drivers.chrome.version=2.33 --singleDriverInstall=chrome --drivers.chrome.baseURL=http://my.mirror.com/chromedriver`
```

Selenium ignore the `--drivers.chrome.baseURL` part and says :

```sh

----------
selenium-standalone installation starting
----------

---
selenium install:
from: http://my.mirror.com/selenium-server/3.6/selenium-server-standalone-3.6.0.jar
to: D:\x\y\z\node_modules\selenium-standalone\.selenium\selenium-server\3.6.0-server.jar
---
chrome install:
from: https://chromedriver.storage.googleapis.com/2.33/chromedriver_win32.zip
to: D:\x\y\z\node_modules\selenium-standalone\.selenium\chromedriver\2.33-x64-chromedriver

```