### PR TITLE
Update default chromedriver to 2.39

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Config file can be a JSON file or a [module file](https://nodejs.org/api/modules
 module.exports = {
   drivers: {
     chrome: {
-      version: '2.31',
+      version: '2.39',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
@@ -105,20 +105,20 @@ var selenium = require('selenium-standalone');
 selenium.install({
   // check for more recent versions of selenium here:
   // https://selenium-release.storage.googleapis.com/index.html
-  version: '3.0.1',
+  version: '3.8.1',
   baseURL: 'https://selenium-release.storage.googleapis.com',
   drivers: {
     chrome: {
       // check for more recent versions of chrome driver here:
       // https://chromedriver.storage.googleapis.com/index.html
-      version: '2.31',
+      version: '2.39',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
     ie: {
       // check for more recent versions of internet explorer driver here:
       // https://selenium-release.storage.googleapis.com/index.html
-      version: '3.0.1',
+      version: '3.9.0',
       arch: process.arch,
       baseURL: 'https://selenium-release.storage.googleapis.com'
     }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,7 +3,7 @@ module.exports = {
   version: '3.8.1',
   drivers: {
     chrome: {
-      version: '2.37',
+      version: '2.39',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },


### PR DESCRIPTION
Chromium [released chromedriver 2.39](https://sites.google.com/a/chromium.org/chromedriver/downloads)

This increases support for stable and beta builds of Chrome (v67 & v68)

Binaries available here:
https://chromedriver.storage.googleapis.com/index.html?path=2.31/