### PR TITLE
Bumped selenium version to 3.12.0 so that it runs in Java 10

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   baseURL: 'https://selenium-release.storage.googleapis.com',
-  version: '3.8.1',
+  version: '3.12.0',
   drivers: {
     chrome: {
       version: '2.37',

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,12 +3,12 @@ module.exports = {
   version: '3.12.0',
   drivers: {
     chrome: {
-      version: '2.37',
+      version: '2.40',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
     ie: {
-      version: '3.9.0',
+      version: '3.12.0',
       arch: process.arch,
       baseURL: 'https://selenium-release.storage.googleapis.com'
     },
@@ -18,7 +18,7 @@ module.exports = {
       baseURL: 'https://github.com/mozilla/geckodriver/releases/download'
     },
     edge: {
-      version: '16299'
+      version: '17134'
     }
   }
 };

--- a/lib/microsoft-edge-releases.js
+++ b/lib/microsoft-edge-releases.js
@@ -24,13 +24,13 @@ module.exports = {
     extension: 'exe'
   },
 
-  'insiders': {
-    url: 'https://download.microsoft.com/download/1/4/1/14156DA0-D40F-460A-B14D-1B264CA081A5/MicrosoftWebDriver.exe',
+  '16299': {
+    url: 'https://download.microsoft.com/download/D/4/1/D417998A-58EE-4EFE-A7CC-39EF9E020768/MicrosoftWebDriver.exe',
     extension: 'exe'
   },
 
-  '16299': {
-    url: 'https://download.microsoft.com/download/D/4/1/D417998A-58EE-4EFE-A7CC-39EF9E020768/MicrosoftWebDriver.exe',
+  '17134': {
+    url: 'https://download.microsoft.com/download/F/8/A/F8AF50AB-3C3A-4BC4-8773-DC27B32988DD/MicrosoftWebDriver.exe',
     extension: 'exe'
   }
 };

--- a/lib/microsoft-edge-releases.js
+++ b/lib/microsoft-edge-releases.js
@@ -4,16 +4,6 @@
  * You can find them at https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads
  */
 module.exports = {
-  '10240': {
-    url: 'https://download.microsoft.com/download/8/D/0/8D0D08CF-790D-4586-B726-C6469A9ED49C/MicrosoftWebDriver.msi',
-    extension: 'msi'
-  },
-
-  '10586': {
-    url: 'https://download.microsoft.com/download/C/0/7/C07EBF21-5305-4EC8-83B1-A6FCC8F93F45/MicrosoftWebDriver.msi',
-    extension: 'msi'
-  },
-
   '14393': {
     url: 'https://download.microsoft.com/download/3/2/D/32D3E464-F2EF-490F-841B-05D53C848D15/MicrosoftWebDriver.exe',
     extension: 'exe'
@@ -21,6 +11,11 @@ module.exports = {
 
   '15063': {
     url: 'https://download.microsoft.com/download/3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/MicrosoftWebDriver.exe',
+    extension: 'exe'
+  },
+
+  'insiders': {
+    url: 'https://download.microsoft.com/download/1/4/1/14156DA0-D40F-460A-B14D-1B264CA081A5/MicrosoftWebDriver.exe',
     extension: 'exe'
   },
 


### PR DESCRIPTION
Compatibility with JRE10 has been added to selenium recently. The workaround that is linked to in #369 hints in this direction.

This would resolve https://github.com/vvo/selenium-standalone/issues/369

I also bumped the versions numbers of chromedriver, iedriver, and edge drivers.

Removed links to webdriver for Edge 12 and 13 because they are no longer offered by Microsoft to make the CI pass.