### PR TITLE
Display Selenium environment information when building and starting the Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,12 @@ RUN selenium-standalone install
 ADD ./scripts/ /home/seluser/scripts
 
 
+# Force using non root user to execute the image
 USER seluser
+
+
+# Display Selenium environment
+RUN . /home/seluser/scripts/utils.sh && print_selenium_env
 
 
 ENTRYPOINT ["sh", "/home/seluser/scripts/start.sh"]

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -1,5 +1,8 @@
+#!/bin/bash
 
-echo "SCREEN_GEOMETRY: ${SCREEN_GEOMETRY}"
+. /home/seluser/scripts/utils.sh && print_selenium_env
+
+echo "Screen Geometry: ${SCREEN_GEOMETRY}"
 
 sudo rm -f /tmp/.X*lock
 

--- a/docker/scripts/utils.sh
+++ b/docker/scripts/utils.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+print_selenium_env () {
+    CHROME_VERSION=$(/usr/bin/google-chrome --version)
+    FIREFOX_VERSION=$(/usr/bin/firefox --version)
+
+    SS_CONFIG=$(npm root -g)/selenium-standalone/lib/default-config.js
+    SELENIUM_SERVER=$(node -p -e "require('$SS_CONFIG').version")
+    CHROME_WD_VERSION=$(node -p -e "require('$SS_CONFIG').drivers.chrome.version")
+    FIREFOX_WD_VERSION=$(node -p -e "require('$SS_CONFIG').drivers.firefox.version")
+
+    echo ""
+    echo ""
+    echo "Selenium environment:"
+    echo ""
+    echo "  * Browsers:"
+    echo "    - ${CHROME_VERSION}"
+    echo "    - ${FIREFOX_VERSION}"
+    echo ""
+    echo "  * Selenium:"
+    echo "    - Server:            ${SELENIUM_SERVER}"
+    echo "    - Chrome webdriver:  ${CHROME_WD_VERSION}"
+    echo "    - Firefox webdriver: ${FIREFOX_WD_VERSION}"
+    echo ""
+    echo ""
+}


### PR DESCRIPTION
2 use cases:
* When building/releasing new version of the Docker image, admin will be able to easily update HISTORY with both browsers and Selenium versions
* When using the Docker image, users will easily be able to debug potential issues