### PR TITLE
[WIP] Update default config to use latest gecko driver

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -13,7 +13,7 @@ module.exports = {
       baseURL: 'https://selenium-release.storage.googleapis.com'
     },
     firefox: {
-      version: '0.20.1',
+      version: '0.23.0',
       arch: process.arch,
       baseURL: 'https://github.com/mozilla/geckodriver/releases/download'
     },


### PR DESCRIPTION
When using the latest version of Firefox, I'm seeing some issues with the default version of gecko driver, updating to the latest release `0.23.0` appears to fix this for me - I'm not sure if there is a wider implication to making this change, I'd love a steer and apologise for adding noise if this is out of scope/not helpful