### PR TITLE
Fixed Issue 420 on Selenium two-digit extension

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -43,7 +43,7 @@ function computeDownloadUrls(opts, askedOpts) {
     selenium: util.format(
       urls.selenium,
       opts.seleniumBaseURL,
-      opts.seleniumVersion.replace(/(\d+\.\d+)\.\d/, "$1"),
+      opts.seleniumVersion.replace(/(\d+\.\d+)\.\d+/, "$1"),
       opts.seleniumVersion
     )
   };


### PR DESCRIPTION
Description: Fixed regex for getting Selenium version with two-digit patch number (e.g. 3.141.59)
Issue Link: vvo#420