### PR TITLE
updated the selenium server jar version

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   baseURL: 'https://selenium-release.storage.googleapis.com',
-  version: '3.141.0',
+  version: '3.141.5',
   drivers: {
     chrome: {
       version: '2.43',


### PR DESCRIPTION
The recent update to `3.141.0` I've found that Selenium throws an exception when run on a single cpu.

```
Exception in thread "main" java.lang.IllegalStateException: Insufficient configured threads: required=3 < max=3 for QueuedThreadPool[qtp707610042]@2a2d45ba{STARTED,3<=3<=3,i=3,q=0}[ReservedThreadExecutor@2f7c2f4f{s=0/1,p=0}]
```

`3.141.5` has now been released, with this fix in.