### PR TITLE
Fix '--singleDriver' overrides '--driver.<browser>.version'

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -51,9 +51,10 @@ function install(opts, cb) {
   }
 
   if (opts.singleDriverInstall) {
-    if(defaultConfig.drivers[opts.singleDriverInstall]) {
+    if(opts.drivers[opts.singleDriverInstall]) {
+      var drivers = opts.drivers;
       opts.drivers = {};
-      opts.drivers[opts.singleDriverInstall] = defaultConfig.drivers[opts.singleDriverInstall];
+      opts.drivers[opts.singleDriverInstall] = drivers[opts.singleDriverInstall];
     }
   }
 


### PR DESCRIPTION
Using the `--singleDriver` option copies the driver from the `defaultConfiguration`. 
However, if this was overridden by using `--driver...` then that will be lost.
I've updated the code to copy it from the current settings, that include the `--driver...` values.