### PR TITLE
Ignore extra drivers from default config file using CLI and custom config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: trusty
+
 language: java
 
 jdk:

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ selenium.install({
       baseURL: 'https://selenium-release.storage.googleapis.com'
     }
   },
+  ignoreExtraDrivers: true,
   proxy: 'http://localproxy.com', // see https://github.com/request/request#proxies
   requestOpts: { // see https://github.com/request/request#requestoptions-callback
     timeout: 10000
@@ -174,6 +175,8 @@ arch [sometimes](https://code.google.com/p/selenium/issues/detail?id=5116#c9).
 
 `baseURL` is used to find the server having the selenium or drivers files.
 
+`opts.ignoreExtraDrivers` only downloads and installs drivers explicity specified.
+
 `opts.basePath` sets the base directory used to store the selenium standalone `.jar` and drivers. Defaults to current working directory + .selenium/
 
 `opts.progressCb(totalLength, progressLength, chunkLength)` will be called if provided with raw bytes length numbers about the current download process. It is used by the command line to show a progress bar.
@@ -190,6 +193,8 @@ arch [sometimes](https://code.google.com/p/selenium/issues/detail?id=5116#c9).
 
 `opts.drivers` map of drivers to run along with selenium standalone server, same
 as `selenium.install`.
+
+`opts.ignoreExtraDrivers` only loads and starts drivers explicity specified.
 
 `opts.basePath` sets the base directory used to load the selenium standalone `.jar` and drivers, same as `selenium.install`.
 

--- a/bin/selenium-standalone
+++ b/bin/selenium-standalone
@@ -5,6 +5,7 @@ var debug = require('debug')('selenium-standalone:cli');
 var minimist = require('minimist');
 var which = require('which');
 var merge = require('lodash').merge;
+var mapValues = require('lodash').mapValues;
 var path = require('path');
 
 var selenium = require('../');
@@ -52,6 +53,13 @@ function parseCommandAndOptions(javaPath) {
 
   // Merge default options, options from config file then command line options
   options = merge({}, defaultConfig, configFromFile, options);
+
+  // Ignore extra default drivers if specified in config file
+  if (configFromFile.drivers && options.ignoreExtraDrivers) {
+    options.drivers = mapValues(configFromFile.drivers, function (config, name) {
+      return merge({}, defaultConfig.drivers[name], config);
+    });
+  }
 
   if (seleniumArgs.length) {
     options.seleniumArgs = seleniumArgs;

--- a/test/cli-parameters.js
+++ b/test/cli-parameters.js
@@ -175,5 +175,22 @@ describe('`selenium-standalone` command parameters', function() {
       expect(parsed[1].seleniumArgs).to.be.deep.equal(['--some=seleniumArgs']);
     });
 
+    it('ignores extra drivers when specified', function () {
+      var defaultConfig = require('../lib/default-config');
+
+      process.argv = buildArgv([
+        'start',
+        '--config=' + path.join(__dirname, 'fixtures', 'config.ignoreExtraDrivers.js')
+      ]);
+
+      var parsed = parseCommandAndOptions('/somewhere');
+
+      expect(parsed[1].drivers.chrome.version).to.be.equal(999);
+      expect(parsed[1].drivers.chrome.baseURL).to.be.equal(defaultConfig.drivers.chrome.baseURL);
+      expect(parsed[1].drivers.ie).to.be.undefined;
+      expect(parsed[1].drivers.edge).to.be.undefined;
+      expect(parsed[1].drivers.firefox).to.be.undefined;
+    });
+
   });
 });

--- a/test/fixtures/config.ignoreExtraDrivers.js
+++ b/test/fixtures/config.ignoreExtraDrivers.js
@@ -1,0 +1,8 @@
+module.exports = {
+  drivers: {
+    chrome: {
+      version: 999
+    }
+  },
+  ignoreExtraDrivers: true
+}


### PR DESCRIPTION
**Issues:** #433, #361, #325 

**Solution:** Add `opts.ignoreExtraDrivers` flag to prevent installing and attempting to start unwanted drivers from default config. When set to `true`, unwanted default config drivers are ignored (e.g., only Chrome is desired and used) when using CLI install/start commands. API install/start commands already function this way. This solution is backward-compatible. Added one new unit test to communicate/validate this new behavior; all existing tests passing. Also verified CLI `start` command with a custom config containing only one driver (Chrome) and option `ignoreExtraDrivers=true` executes successfully without error when other drivers (IE, Firefox, Edge) are not installed. Also added documentation of new config option to README.

**Edit:** Fixed failing Travis checks by adding `dist: trusty` to .travis.yml thanks to [this suggestion](https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/6).