### PR TITLE
add support for chromium edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Supported WebDrivers:
  * [FirefoxDriver](https://github.com/SeleniumHQ/selenium/wiki/FirefoxDriver)
  * [IEDriver](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver)
  * [Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads)
+ * [Chromium Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads)
 
 
 ## Install & Run
@@ -86,7 +87,7 @@ selenium-standalone install --drivers.chrome.version=2.15 --drivers.chrome.baseU
 # choose ie driver architecture
 selenium-standalone start --drivers.ie.arch=ia32 --drivers.ie.baseURL=https://selenium-release.storage.googleapis.com
 
-# install a single driver within the default list (chrome, ie, edge, firefox)
+# install a single driver within the default list (chrome, ie, edge, firefox, chromiumedge)
 selenium-standalone install --singleDriverInstall=chrome
 
 # specify hub and nodes to setup your own selenium grid

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -6,7 +6,8 @@ var urls = {
   selenium: '%s/%s/selenium-server-standalone-%s.jar',
   chrome: '%s/%s/chromedriver_%s.zip',
   ie: '%s/%s/IEDriverServer_%s_%s.zip',
-  firefox: '%s/%s/%s-%s-%s'
+  firefox: '%s/%s/%s-%s-%s',
+  chromiumedge: '%s/%s/edgedriver_%s.zip'
 };
 
 var mac32;
@@ -79,6 +80,14 @@ function computeDownloadUrls(opts, askedOpts) {
   }
   if (opts.drivers.edge) {
     downloadUrls.edge = getEdgeDriverUrl(opts.drivers.edge.version);
+  }
+  if (opts.drivers.chromiumedge) {
+    downloadUrls.chromiumedge = util.format(
+      urls.chromiumedge,
+      opts.drivers.chromiumedge.baseURL,
+      opts.drivers.chromiumedge.version,
+      getChromiumEdgeDriverArchitecture(opts.drivers.chromiumedge.arch)
+    );
   }
 
   return downloadUrls;
@@ -253,6 +262,42 @@ function getEdgeDriverUrl(version) {
   }
 
   return release.url
+}
+
+function getChromiumEdgeDriverArchitecture(wantedArchitecture) {
+  var platform;
+
+  if (process.platform === 'linux') {
+    platform = getLinuxChromiumEdgeDriverArchitecture(wantedArchitecture);
+  } else if (process.platform === 'darwin') {
+    platform = getMacChromiumEdgeDriverArchitecture(wantedArchitecture);
+  } else {
+    if (wantedArchitecture === 'x32') {
+      platform = 'win32';
+    } else {
+      platform = 'win64';
+    }
+  }
+
+  return platform;
+}
+
+function getLinuxChromiumEdgeDriverArchitecture(wantedArchitecture) {
+  // chromium edge supports linux 64 only
+  if(wantedArchitecture !== 'x64') {
+    throw new Error('Only x64 architecture is available for chroimum edge driver for linux')
+  }
+
+  return 'linux64';
+}
+
+function getMacChromiumEdgeDriverArchitecture(wantedArchitecture) {
+  // chromium edge supports mac 64 only
+  if(wantedArchitecture !== 'x64') {
+    throw new Error('Only x64 architecture is available for chroimum edge driver for mac')
+  }
+
+  return 'mac64';
 }
 
 function compareVersions (v1, v2) {

--- a/lib/compute-fs-paths.js
+++ b/lib/compute-fs-paths.js
@@ -31,6 +31,12 @@ function computeFsPaths(opts) {
     };
   }
 
+  if (opts.drivers.chromiumedge) {
+    fsPaths.chromiumedge = {
+      installPath: path.join(opts.basePath, 'chromiumedgedriver', opts.drivers.chromiumedge.version + '-' + opts.drivers.chromiumedge.arch + '-msedgedriver')
+    };
+  }
+
   fsPaths.selenium = {
     installPath: path.join(opts.basePath, 'selenium-server', opts.seleniumVersion + '-server.jar')
   };

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -19,6 +19,11 @@ module.exports = {
     },
     edge: {
       version: '17134'
+    },
+    chromiumedge: {
+      version: '86.0.600.0',
+      arch: process.arch,
+      baseURL: 'https://msedgedriver.azureedge.net'
     }
   }
 };

--- a/lib/install.js
+++ b/lib/install.js
@@ -174,6 +174,14 @@ function install(opts, cb) {
       })
     }
 
+    if (opts.fsPaths.chromiumedge) {
+      installers.push({
+        installer: installChromiumEdgeDr,
+        from: opts.urls.chromiumedge,
+        to: opts.fsPaths.chromiumedge.downloadPath
+      })
+    }
+
     var steps = installers.map(function (opts) {
       return onlyInstallMissingFiles.bind(null, opts);
     });
@@ -290,6 +298,10 @@ function install(opts, cb) {
     }
   }
 
+  function installChromiumEdgeDr(opts, cb) {
+    installZippedFile(opts.from, opts.to, cb);
+  }
+
   function installGzippedFile(from, to, cb) {
     getDownloadStream(from, function(err, stream) {
       if (err) {
@@ -397,13 +409,15 @@ function install(opts, cb) {
     var yauzl = require('yauzl');
     var extractPath = path.join(path.dirname(zipFilePath), path.basename(zipFilePath, '.zip'));
 
-    yauzl.open(zipFilePath, {lazyEntries: true}, function onOpenZipFile(err, zipFile) {
+    yauzl.open(zipFilePath, function onOpenZipFile(err, zipFile) {
       if (err) {
         cb(err);
         return;
       }
-      zipFile.readEntry();
-      zipFile.once('entry', function (entry) {
+      zipFile.on('entry', function (entry) {
+        if (/.*\/.*/.test(entry.fileName)) {
+          return; // ignore folders, i.e. release notes folder in edge driver zip
+        }
         zipFile.openReadStream(entry, function onOpenZipFileEntryReadStream(err, readStream) {
           if (err) {
             cb(err);
@@ -487,7 +501,7 @@ function setDriverFilePermissions(where, cb) {
 }
 
 function logInstallSummary(logger, paths, urls) {
-  ['selenium', 'chrome', 'ie', 'firefox', 'edge'].forEach(function log(name) {
+  ['selenium', 'chrome', 'ie', 'firefox', 'edge', 'chromiumedge'].forEach(function log(name) {
     if (!paths[name]) {
       return;
     }

--- a/lib/start.js
+++ b/lib/start.js
@@ -93,6 +93,10 @@ function start(opts, cb) {
     args.push('-Dwebdriver.gecko.driver=' + fsPaths.firefox.installPath);
   }
 
+  if (fsPaths.chromiumedge) {
+    args.push('-Dwebdriver.edge.driver=' + fsPaths.chromiumedge.installPath);
+  }
+
   args = args.concat(opts.javaArgs);
 
   args = args.concat(['-jar', fsPaths.selenium.installPath]);

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -573,4 +573,104 @@ describe('compute-download-urls', function() {
       })
     });
   });
+
+  describe('chromiumedge', function() {
+    beforeEach(function() {
+      opts = {
+        seleniumVersion: '1.0',
+        seleniumBaseURL: 'https://localhost',
+        drivers: {
+          chromiumedge: {}
+        }
+      };
+    });
+
+    describe('linux', function() {
+      before(function() {
+        Object.defineProperty(process, 'platform', {
+          value: 'linux'
+        });
+      });
+
+      it('throws for x32 arch', function() {
+        opts.drivers.chromiumedge = {
+          baseURL: 'https://localhost',
+          version: '86.0.600.0',
+          arch: 'x32'
+        }
+
+        assert.throws(() => computeDownloadUrls(opts), 'Only x64 is supported for linux');
+      });
+
+      it('x64', function() {
+        opts.drivers.chromiumedge = {
+          baseURL: 'https://localhost',
+          version: '86.0.600.0',
+          arch: 'x64'
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_linux64.zip');
+      });
+    });
+
+    describe('mac', function() {
+      before(function() {
+        Object.defineProperty(process, 'platform', {
+          value: 'darwin'
+        });
+      });
+
+      it('throws for x32 arch', function() {
+        opts.drivers.chromiumedge = {
+          baseURL: 'https://localhost',
+          version: '86.0.600.0',
+          arch: 'x32'
+        }
+
+        assert.throws(() => computeDownloadUrls(opts), 'Only x64 is supported for mac');
+      })
+
+      it('x64', function() {
+        opts.drivers.chromiumedge = {
+          baseURL: 'https://localhost',
+          version: '86.0.600.0',
+          arch: 'x64'
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_mac64.zip');
+      })
+    });
+
+    describe('win', function() {
+      before(function() {
+        Object.defineProperty(process, 'platform', {
+          value: 'win32'
+        });
+      });
+
+      it('x32', function() {
+        opts.drivers.chromiumedge = {
+          baseURL: 'https://localhost',
+          version: '86.0.600.0',
+          arch: 'x32'
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_win32.zip');
+      });
+
+      it('x64', function() {
+        opts.drivers.chromiumedge = {
+          baseURL: 'https://localhost',
+          version: '86.0.600.0',
+          arch: ''
+        }
+
+        var actual = computeDownloadUrls(opts);
+        assert.equal(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_win64.zip');
+      });
+    });
+  });
 });

--- a/test/no-reinstall.js
+++ b/test/no-reinstall.js
@@ -1,6 +1,8 @@
 describe('when files are installed', function () {
     it('should not reinstall them', function (done) {
 
+        this.timeout(120000);
+
         var fs = require('fs');
         var path = require('path');
         var targetDir = path.join(__dirname, '..', '.selenium');


### PR DESCRIPTION
Add a new browser to the list of supported ones: Chromium Edge.
This change does not affect legacy edge, as there could be some users who might still want to use it.

The webdriver unzipping process was also slightly updated to support zips which might contain folders and not just the webdriver binary (which is the case for the latest chromium edge drivers)