### PR TITLE
Modified ChromiumEdge InstallPath.

### DIFF
--- a/lib/compute-fs-paths.js
+++ b/lib/compute-fs-paths.js
@@ -33,7 +33,7 @@ function computeFsPaths(opts) {
 
   if (opts.drivers.chromiumedge) {
     fsPaths.chromiumedge = {
-      installPath: path.join(opts.basePath, 'chromiumedgedriver', opts.drivers.chromiumedge.version + '-' + opts.drivers.chromiumedge.arch + '-msedgedriver')
+      installPath: path.join(opts.basePath, 'chromiumedgedriver', 'msedgedriver')
     };
   }
 


### PR DESCRIPTION
Hi @vvo. This PR will help to resolve below issue.

After added support for chromiumEdge driver, when i try to override the chromiumEdge version with my browser version from **WebdriverIO** services i mean from install args like below.

![OverrideEdgeChromiumVersion](https://user-images.githubusercontent.com/40600297/92936961-5e0e6800-f468-11ea-95af-2adf5ea2f2f7.png)

Getting Error :  works with chromium edge 86 version.  

![SupportEdge86Version](https://user-images.githubusercontent.com/40600297/92949695-22c86500-f479-11ea-90f3-98d7955d07ae.png)

Removing the preceding version and arch before msedgedriver will work even the version value gets overridden from install args of WebdriverIO Services . Thanks ! 