### PR TITLE
Support latest as browser driver version

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,19 @@
+# 6.22.0 (2020-11-27)
+* chrome, edgechromium, and geckodriver support `latest` as version
+* replaced `async` package with native promises
+* resolved issues #468 #502 #511
+
+# 6.21.0 (2020-11-26)
+* resolved issues #357 #457 #376 #488 #489
+* replaced `request` with `got`
+* update diedriver version to `3.150.1`
+* updated chromiumedge version to `87.0.637.0`
+* updated geckodriver version to `87.0.637.0`
+* decreased package size by 60% (8.6Mb)
+* nodejs version in docker updated to 12
+* added eslint + prettier
+* minor bug fixes
+
 # 6.20.1 (2020-10-09)
 * Fix chromiumedge privileges
   

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 Supported WebDrivers:
 
  * [ChromeDriver](https://github.com/SeleniumHQ/selenium/wiki/ChromeDriver)
- * [FirefoxDriver](https://github.com/SeleniumHQ/selenium/wiki/FirefoxDriver)
+ * [geckodriver](https://github.com/mozilla/geckodriver/releases) (Firefox)
  * [IEDriver](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver)
  * [Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads)
  * [Chromium Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ See [API](./docs/API.md) docs
 
 By default, Google Chrome, Firefox and Microsoft Edge are available when installed on the host system.
 
+Starting from `v6.22` chrome, edgechromium, and geckodriver support `latest` as version.
+
 ## Tips
 
 - [Start Selenium whenever your (ubuntu) machine starts!](./docs/run-when-system-starts.md)

--- a/lib/check-paths-existence.js
+++ b/lib/check-paths-existence.js
@@ -2,7 +2,7 @@ module.exports = checkPathsExistence;
 
 const fs = require('fs');
 
-function checkPathsExistence(paths) {
+function checkPathsExistence(paths, cb) {
   const pathValues = Object.keys(paths).map((key) => {
     return paths[key];
   });
@@ -20,5 +20,5 @@ function checkPathsExistence(paths) {
           });
         })
     )
-  );
+  ).then(() => cb());
 }

--- a/lib/check-paths-existence.js
+++ b/lib/check-paths-existence.js
@@ -1,26 +1,24 @@
 module.exports = checkPathsExistence;
 
-const async = require('async');
 const fs = require('fs');
 
-function checkPathsExistence(paths, cb) {
+function checkPathsExistence(paths) {
   const pathValues = Object.keys(paths).map((key) => {
     return paths[key];
   });
 
-  async.parallel(
-    pathValues.map((path) => {
-      return function (existsCb) {
-        fs.exists(path, (res) => {
-          if (res === false) {
-            existsCb(new Error('Missing ' + path));
-            return;
-          }
+  Promise.all(
+    pathValues.map(
+      (path) =>
+        new Promise((resolve, reject) => {
+          fs.exists(path, (res) => {
+            if (res === false) {
+              return reject(new Error('Missing ' + path));
+            }
 
-          existsCb();
-        });
-      };
-    }),
-    cb
+            resolve();
+          });
+        })
+    )
   );
 }

--- a/lib/check-paths-existence.js
+++ b/lib/check-paths-existence.js
@@ -20,5 +20,7 @@ function checkPathsExistence(paths, cb) {
           });
         })
     )
-  ).then(() => cb());
+  )
+    .then(() => cb())
+    .catch((err) => cb(err));
 }

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -1,5 +1,6 @@
 module.exports = computeDownloadUrls;
 
+const got = require('got');
 const util = require('util');
 
 const urls = {
@@ -36,7 +37,7 @@ let mac32;
  * @param {string} opts.seleniumBaseURL - Base URL for where to download selenium.jar from
  * @param {Object} opts.drivers - Object containing options for various drivers. See comment for object format.
  */
-function computeDownloadUrls(opts) {
+async function computeDownloadUrls(opts) {
   // 2.44.0 => 2.44
   // 2.44.0 would be `patch`, 2.44 `minor`, 2 `major` as per semver
 
@@ -49,8 +50,14 @@ function computeDownloadUrls(opts) {
     ),
   };
   if (opts.drivers.chrome) {
-    if (opts.drivers.chrome.version < 2.23) {
-      mac32 = true;
+    if (opts.drivers.chrome.version === 'latest') {
+      try {
+        const response = await got(opts.drivers.chrome.baseURL + '/LATEST_RELEASE', { timeout: 10000 });
+        // eslint-disable-next-line no-param-reassign
+        opts.drivers.chrome.version = response.body;
+      } catch (_) {
+        // eslint-disable-next-line no-empty
+      }
     }
     downloadUrls.chrome = util.format(
       urls.chrome,

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -50,15 +50,7 @@ async function computeDownloadUrls(opts) {
     ),
   };
   if (opts.drivers.chrome) {
-    if (opts.drivers.chrome.version === 'latest') {
-      try {
-        const response = await got(opts.drivers.chrome.baseURL + '/LATEST_RELEASE', { timeout: 10000 });
-        // eslint-disable-next-line no-param-reassign
-        opts.drivers.chrome.version = response.body;
-      } catch (_) {
-        // eslint-disable-next-line no-empty
-      }
-    }
+    await resolveLatestVersion(opts, 'chrome', opts.drivers.chrome.baseURL + '/LATEST_RELEASE');
     downloadUrls.chrome = util.format(
       urls.chrome,
       opts.drivers.chrome.baseURL,
@@ -89,6 +81,11 @@ async function computeDownloadUrls(opts) {
     downloadUrls.edge = getEdgeDriverUrl(opts.drivers.edge.version);
   }
   if (opts.drivers.chromiumedge) {
+    await resolveLatestVersion(
+      opts,
+      'chromiumedge',
+      'https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/LATEST_STABLE'
+    );
     downloadUrls.chromiumedge = util.format(
       urls.chromiumedge,
       opts.drivers.chromiumedge.baseURL,
@@ -347,4 +344,19 @@ function compareVersions(v1, v2) {
     }
   }
   return 0;
+}
+
+async function resolveLatestVersion(opts, browserDriver, url) {
+  if (opts.drivers[browserDriver].version === 'latest') {
+    try {
+      const response = await got(url, { timeout: 10000 });
+      // eslint-disable-next-line no-param-reassign
+      opts.drivers[browserDriver].version = response.body
+        // edgewebdriver latest version file contains invalid characters
+        .replace(/\r|\n/g, '')
+        .replace(/[^\d|.]/g, '');
+    } catch (_) {
+      // eslint-disable-next-line no-empty
+    }
+  }
 }

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -51,6 +51,9 @@ async function computeDownloadUrls(opts) {
   };
   if (opts.drivers.chrome) {
     await resolveLatestVersion(opts, 'chrome', opts.drivers.chrome.baseURL + '/LATEST_RELEASE');
+    if (opts.drivers.chrome.version < 2.23) {
+      mac32 = true;
+    }
     downloadUrls.chrome = util.format(
       urls.chrome,
       opts.drivers.chrome.baseURL,
@@ -303,9 +306,6 @@ function getMacChromiumEdgeDriverArchitecture(wantedArchitecture) {
 }
 
 function compareVersions(v1, v2) {
-  if (v1 === 'latest') {
-    return 1;
-  }
   function split(flag, version) {
     let result = [];
     if (flag) {

--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -68,6 +68,7 @@ async function computeDownloadUrls(opts) {
     );
   }
   if (opts.drivers.firefox) {
+    await resolveLatestVersion(opts, 'firefox', 'https://api.github.com/repos/mozilla/geckodriver/releases/latest');
     downloadUrls.firefox = util.format(
       urls.firefox,
       opts.drivers.firefox.baseURL,
@@ -302,6 +303,9 @@ function getMacChromiumEdgeDriverArchitecture(wantedArchitecture) {
 }
 
 function compareVersions(v1, v2) {
+  if (v1 === 'latest') {
+    return 1;
+  }
   function split(flag, version) {
     let result = [];
     if (flag) {
@@ -349,14 +353,36 @@ function compareVersions(v1, v2) {
 async function resolveLatestVersion(opts, browserDriver, url) {
   if (opts.drivers[browserDriver].version === 'latest') {
     try {
-      const response = await got(url, { timeout: 10000 });
-      // eslint-disable-next-line no-param-reassign
-      opts.drivers[browserDriver].version = response.body
-        // edgewebdriver latest version file contains invalid characters
-        .replace(/\r|\n/g, '')
-        .replace(/[^\d|.]/g, '');
+      if (browserDriver === 'firefox') {
+        if (await getLatestGeckodriver(opts, browserDriver, url)) {
+          return true;
+        }
+      } else if (await getLatestChromium(opts, browserDriver, url)) {
+        return true;
+      }
     } catch (_) {
-      // eslint-disable-next-line no-empty
+      // eslint-disable-next-line no-param-reassign
     }
+    // eslint-disable-next-line no-param-reassign
+    opts.drivers[browserDriver].version = opts.drivers[browserDriver].fallbackVersion;
+  }
+}
+
+async function getLatestChromium(opts, browserDriver, url) {
+  const response = await got(url, { timeout: 10000 });
+  // eslint-disable-next-line no-param-reassign
+  opts.drivers[browserDriver].version = response.body
+    // edgewebdriver latest version file contains invalid characters
+    .replace(/\r|\n/g, '')
+    .replace(/[^\d|.]/g, '');
+  return true;
+}
+
+async function getLatestGeckodriver(opts, browserDriver, url) {
+  const response = await got(url, { timeout: 10000, responseType: 'json' });
+  if (typeof response.body.name === 'string') {
+    // eslint-disable-next-line no-param-reassign
+    opts.drivers[browserDriver].version = response.body.name;
+    return true;
   }
 }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,7 +3,7 @@ const config = {
   version: '3.141.59',
   drivers: {
     chrome: {
-      version: '87.0.4280.20',
+      version: 'latest',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com',
     },

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -26,7 +26,7 @@ const config = {
 // disabled chromiumedge because https://msedgedriver.azureedge.net doesn't support caching
 if (!process.env.SS_TESTING) {
   config.drivers.chromiumedge = {
-    version: '87.0.664.47',
+    version: 'latest',
     arch: process.arch,
     baseURL: 'https://msedgedriver.azureedge.net',
   };

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -4,6 +4,7 @@ const config = {
   drivers: {
     chrome: {
       version: 'latest',
+      fallbackVersion: '87.0.4280.20',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com',
     },
@@ -13,7 +14,8 @@ const config = {
       baseURL: 'https://selenium-release.storage.googleapis.com',
     },
     firefox: {
-      version: '0.28.0',
+      version: 'latest',
+      fallbackVersion: '0.28.0',
       arch: process.arch,
       baseURL: 'https://github.com/mozilla/geckodriver/releases/download',
     },
@@ -27,6 +29,7 @@ const config = {
 if (!process.env.SS_TESTING) {
   config.drivers.chromiumedge = {
     version: 'latest',
+    fallbackVersion: '87.0.637.0',
     arch: process.arch,
     baseURL: 'https://msedgedriver.azureedge.net',
   };

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -26,7 +26,7 @@ const config = {
 // disabled chromiumedge because https://msedgedriver.azureedge.net doesn't support caching
 if (!process.env.SS_TESTING) {
   config.drivers.chromiumedge = {
-    version: '87.0.637.0',
+    version: '87.0.664.47',
     arch: process.arch,
     baseURL: 'https://msedgedriver.azureedge.net',
   };

--- a/lib/install-utils.js
+++ b/lib/install-utils.js
@@ -3,7 +3,8 @@ const os = require('os');
 const crypto = require('crypto');
 const mkdirp = require('mkdirp');
 const path = require('path');
-const async = require('async');
+const yauzl = require('yauzl');
+const gunzip = require('zlib').createGunzip();
 const fs = require('fs');
 const got = require('got');
 const merge = require('lodash.merge');
@@ -33,50 +34,56 @@ const logInstallSummary = (logger, paths, urls) => {
   });
 };
 
-function asyncLogEnd(logger, cb) {
-  setImmediate(() => {
-    logger('');
-    logger('');
-    logger('-----');
-    logger('selenium-standalone installation finished');
-    logger('-----');
-    cb();
-  });
+function asyncLogEnd(logger) {
+  logger('');
+  logger('-----');
+  logger('selenium-standalone installation finished');
+  logger('-----');
 }
 
-function createDirs(paths, cb) {
+async function createDirs(paths) {
   const installDirectories = Object.keys(paths).map((name) => {
     return paths[name].installPath;
   });
 
-  async.eachSeries(installDirectories.map(basePath), mkdirp, cb);
+  for (const d of installDirectories.map(basePath)) {
+    await mkdirp(d);
+  }
+
+  // async.eachSeries(installDirectories.map(basePath), mkdirp, cb);
 }
 
-function setDriverFilePermissions(where, cb) {
+const chmod = (where) =>
+  new Promise((resolve, reject) => {
+    debug('chmod 0755 on', where);
+    fs.chmod(where, '0755', (err) => {
+      if (err) {
+        return reject(err);
+      }
+      resolve();
+    });
+  });
+
+async function setDriverFilePermissions(where) {
   debug('setDriverFilePermissions', where);
 
-  const chmod = () => {
-    debug('chmod 0755 on', where);
-    fs.chmod(where, '0755', cb);
-  };
+  const requireChmod = await new Promise((resolve) =>
+    fs.access(where, fs.R_OK | fs.X_OK, (err) => {
+      if (err) {
+        debug('error in fs.access', where, err);
+      }
+      resolve(!!err);
+    })
+  );
 
-  // node.js 0.10.x does not support fs.access
-  fs.stat(where, (err, stat) => {
-    debug('%s stats : %O', where, stat);
-  });
-  fs.access(where, fs.R_OK | fs.X_OK, (err) => {
-    if (err) {
-      debug('error in fs.access', where, err);
-      chmod();
-    } else {
-      return cb();
-    }
-  });
+  if (requireChmod) {
+    await chmod(where);
+  }
 }
 
 function checksum(filepath, cb) {
   if (!fs.existsSync(filepath)) {
-    return cb(null, null);
+    return cb(null);
   }
 
   const hash = crypto.createHash('md5');
@@ -87,14 +94,14 @@ function checksum(filepath, cb) {
       hash.update(data, 'utf8');
     })
     .on('end', () => {
-      cb(null, hash.digest('hex'));
+      cb(hash.digest('hex'));
     })
     .once('error', cb);
 }
 
 function isUpToDate(url, requestOpts, hash, cb) {
   if (!hash) {
-    return cb(null, false);
+    return cb(false);
   }
 
   const options = merge({}, requestOpts, {
@@ -105,9 +112,9 @@ function isUpToDate(url, requestOpts, hash, cb) {
   got(url, options)
     .then((res) => {
       if (res.statusCode === 304) {
-        return cb(null, true);
+        return cb(true);
       }
-      cb(null, false);
+      cb(false);
     })
     .catch((err) => {
       return cb(new Error(`Could not request headers from ${url}: ${err.response.statusCode}`));
@@ -118,87 +125,75 @@ function getTempFileName(suffix) {
   return os.tmpdir() + path.sep + os.uptime() + suffix;
 }
 
-function uncompressDownloadedFile(zipFilePath, cb) {
+async function uncompressDownloadedFile(zipFilePath) {
   debug('unzip ' + zipFilePath);
 
-  const yauzl = require('yauzl');
-
-  yauzl.open(zipFilePath, function onOpenZipFile(err, zipFile) {
-    if (err) {
-      cb(err);
-      return;
-    }
-    zipFile.on('entry', (entry) => {
-      if (/.*\/.*/.test(entry.fileName)) {
-        return; // ignore folders, i.e. release notes folder in edge driver zip
+  return new Promise((resolve, reject) =>
+    yauzl.open(zipFilePath, function onOpenZipFile(err, zipFile) {
+      if (err) {
+        return reject(err);
       }
-      zipFile.openReadStream(entry, { autoClose: true }, function onOpenZipFileEntryReadStream(errRead, readStream) {
-        if (errRead) {
-          cb(errRead);
-          return;
+      zipFile.on('entry', (entry) => {
+        if (/.*\/.*/.test(entry.fileName)) {
+          return; // ignore folders, i.e. release notes folder in edge driver zip
         }
-        const extractPath = path.join(
-          path.dirname(zipFilePath),
-          isBrowserDriver(entry.fileName) ? path.basename(zipFilePath, '.zip') : entry.fileName
-        );
-        const extractWriteStream = fs
-          .createWriteStream(extractPath)
-          .once('error', cb.bind(null, new Error('Could not write to ' + extractPath)));
-        readStream.pipe(extractWriteStream).once('error', cb.bind(null, new Error('Could not read ' + zipFilePath)));
-      });
-    });
-    zipFile.on('close', () => {
-      cb();
-    });
-  });
-}
-
-function uncompressGzippedFile(from, gzipFilePath, cb) {
-  const gunzip = require('zlib').createGunzip();
-  const extractPath = path.join(path.dirname(gzipFilePath), path.basename(gzipFilePath, '.gz'));
-  const writeStream = fs.createWriteStream(extractPath).once('error', () => {
-    cb.bind(null, new Error('Could not write to ' + extractPath));
-  });
-  const gunzippedContent = fs
-    .createReadStream(gzipFilePath)
-    .pipe(gunzip)
-    .once('error', cb.bind(null, new Error('Could not read ' + gzipFilePath)));
-
-  if (from.substr(-7) === '.tar.gz') {
-    const extractor = tarStream.extract();
-    let fileAlreadyUnarchived = false;
-    let cbCalled = false;
-
-    extractor
-      .on('entry', (header, stream, callback) => {
-        if (fileAlreadyUnarchived) {
-          if (!cbCalled) {
-            cb(new Error('Tar archive contains more than one file'));
-            cbCalled = true;
+        zipFile.openReadStream(entry, { autoClose: true }, function onOpenZipFileEntryReadStream(errRead, readStream) {
+          if (errRead) {
+            return reject(errRead);
           }
-          fileAlreadyUnarchived = true;
-        }
-        stream.pipe(writeStream);
-        stream.on('end', () => {
-          callback();
+          const extractPath = path.join(
+            path.dirname(zipFilePath),
+            isBrowserDriver(entry.fileName) ? path.basename(zipFilePath, '.zip') : entry.fileName
+          );
+          const extractWriteStream = fs.createWriteStream(extractPath).once('error', reject);
+          readStream.pipe(extractWriteStream).once('error', reject);
         });
-        stream.resume();
-      })
-      .on('finish', () => {
-        if (!cbCalled) {
-          cb();
-          cbCalled = true;
-        }
       });
-    gunzippedContent.pipe(extractor);
-  } else {
-    gunzippedContent.pipe(writeStream).on('finish', () => {
-      cb();
-    });
-  }
+      zipFile.on('close', resolve);
+    })
+  );
 }
 
-function runInstaller(installerFile, from, to, cb) {
+async function uncompressGzippedFile(from, gzipFilePath) {
+  return new Promise((resolve, reject) => {
+    const extractPath = path.join(path.dirname(gzipFilePath), path.basename(gzipFilePath, '.gz'));
+    const writeStream = fs.createWriteStream(extractPath).once('error', reject);
+    const gunzippedContent = fs.createReadStream(gzipFilePath).pipe(gunzip).once('error', reject);
+
+    if (from.substr(-7) === '.tar.gz') {
+      const extractor = tarStream.extract();
+      let fileAlreadyUnarchived = false;
+      let cbCalled = false;
+
+      extractor
+        .on('entry', (header, stream, callback) => {
+          if (fileAlreadyUnarchived) {
+            if (!cbCalled) {
+              cbCalled = true;
+              return reject(new Error('Tar archive contains more than one file'));
+            }
+            fileAlreadyUnarchived = true;
+          }
+          stream.pipe(writeStream);
+          stream.on('end', () => {
+            callback();
+          });
+          stream.resume();
+        })
+        .on('finish', () => {
+          if (!cbCalled) {
+            cbCalled = true;
+            resolve();
+          }
+        });
+      gunzippedContent.pipe(extractor);
+    } else {
+      gunzippedContent.pipe(writeStream).on('finish', resolve);
+    }
+  });
+}
+
+async function runInstaller(installerFile, from, to) {
   const logFile = getTempFileName('installer.log');
   const options = [
     '/passive', // no user interaction, only show progress bar
@@ -211,41 +206,35 @@ function runInstaller(installerFile, from, to, cb) {
   const spawn = require('cross-spawn');
   const runner = spawn('msiexec', options, { stdio: 'inherit' });
 
-  runner.on('exit', () => {
-    fs.readFile(logFile, 'utf16le', (err, data) => {
-      if (err) {
-        return cb(err);
-      }
+  return new Promise((resolve, reject) => {
+    runner.on('exit', () => {
+      fs.readFile(logFile, 'utf16le', (err, data) => {
+        if (err) {
+          return reject(err);
+        }
 
-      const installDir = data
-        .split(os.EOL)
-        .map((line) => {
-          const match = line.match(/INSTALLDIR = (.+)$/);
-          return match && match[1];
-        })
-        .filter((line) => {
-          return line != null;
-        })[0];
+        const installDir = data
+          .split(os.EOL)
+          .map((line) => {
+            const match = line.match(/INSTALLDIR = (.+)$/);
+            return match && match[1];
+          })
+          .filter((line) => line != null)[0];
 
-      if (installDir) {
+        if (!installDir) {
+          return reject(new Error('Could not find installed driver'));
+        }
+
         fs.createReadStream(installDir + 'MicrosoftWebDriver.exe', {
           autoClose: true,
         })
           .pipe(fs.createWriteStream(to, { autoClose: true }))
-          .once('finish', () => {
-            cb();
-          })
-          .once('error', (errWrite) => {
-            cb(errWrite);
-          });
-      } else {
-        cb(new Error('Could not find installed driver'));
-      }
+          .once('finish', resolve)
+          .once('error', reject);
+      });
     });
-  });
 
-  runner.on('error', (err) => {
-    cb(err);
+    runner.on('error', reject);
   });
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-shadow */
 module.exports = install;
 
-const async = require('async');
 const fs = require('fs');
 const path = require('path');
 const got = require('got');
@@ -32,7 +31,7 @@ const { checkArgs } = require('./check-args');
  */
 const downloadStreams = new Map();
 
-function install(_opts, _cb) {
+async function install(_opts, _cb) {
   const { opts, cb } = checkArgs('Install API', _opts, _cb);
 
   const logger = opts.logger || noop;
@@ -85,7 +84,7 @@ function install(_opts, _cb) {
     basePath: opts.basePath,
   });
 
-  const urls = computeDownloadUrls({
+  const urls = await computeDownloadUrls({
     seleniumVersion: opts.version,
     seleniumBaseURL: opts.baseURL,
     drivers: opts.drivers,
@@ -108,38 +107,34 @@ function install(_opts, _cb) {
       tasks.push(setDriverFilePermissions.bind(null, installPath));
     });
 
-  async.series(tasks, (err) => {
-    cb(err, fsPaths);
-  });
+  const results = [];
+  for (const t of tasks) {
+    try {
+      results.push(await t());
+    } catch (err) {
+      return cb(err, fsPaths);
+    }
+  }
+  cb();
 
-  function onlyInstallMissingFiles(opts, cb) {
-    async.waterfall(
-      [checksum.bind(null, opts.to), isUpToDate.bind(null, opts.from, requestOpts)],
-      (error, isLatest) => {
-        if (error) {
-          return cb(error);
-        }
+  async function onlyInstallMissingFiles(opts) {
+    const hash = await new Promise((resolve) => checksum(opts.to, resolve));
+    const isLatest = await new Promise((resolve) => isUpToDate(opts.from, requestOpts, hash, resolve));
 
-        // File already exists. Prevent download/installation.
-        if (isLatest) {
-          logger('---');
-          logger('File from ' + opts.from + ' has already been downloaded');
-          return cb();
-        }
+    // File already exists. Prevent download/installation.
+    if (isLatest) {
+      logger('---');
+      logger('File from ' + opts.from + ' has already been downloaded');
+      return;
+    }
 
-        opts.installer.call(
-          null,
-          {
-            to: opts.to,
-            from: opts.from,
-          },
-          cb
-        );
-      }
-    );
+    return opts.installer({
+      to: opts.to,
+      from: opts.from,
+    });
   }
 
-  function download(opts, cb) {
+  async function download(opts) {
     const installers = [
       {
         installer: installSelenium,
@@ -188,137 +183,123 @@ function install(_opts, _cb) {
       });
     }
 
-    const steps = installers.map((opts) => {
-      return onlyInstallMissingFiles.bind(null, opts);
-    });
-
-    async.parallel(steps, cb);
+    return Promise.all(installers.map((opts) => onlyInstallMissingFiles(opts)));
   }
 
-  function installSelenium(opts, cb) {
-    installSingleFile(opts.from, opts.to, cb);
+  function installSelenium(opts) {
+    return installSingleFile(opts.from, opts.to);
   }
 
-  function installEdgeDr(opts, cb) {
+  function installEdgeDr(opts) {
     if (path.extname(opts.from) === '.msi') {
-      downloadInstallerFile(opts.from, opts.to, cb);
-    } else {
-      installSingleFile(opts.from, opts.to, cb);
+      return downloadInstallerFile(opts.from, opts.to);
     }
+    return installSingleFile(opts.from, opts.to);
   }
 
-  function installSingleFile(from, to, cb) {
-    getDownloadStream(from, (err, stream) => {
-      if (err) {
-        return cb(err);
-      }
+  async function installSingleFile(from, to) {
+    const stream = await getDownloadStream(from);
 
-      stream
-        .pipe(fs.createWriteStream(to))
-        .once('error', cb.bind(null, new Error('Could not write to ' + to)))
-        .once('finish', cb);
-    });
+    return new Promise((resolve, reject) =>
+      stream.pipe(fs.createWriteStream(to)).once('error', reject).once('finish', resolve)
+    );
   }
 
-  function downloadInstallerFile(from, to, cb) {
+  async function downloadInstallerFile(from, to) {
     if (process.platform !== 'win32') {
       throw new Error('Could not install an `msi` file on the current platform');
     }
 
-    getDownloadStream(from, (err, stream) => {
-      if (err) {
-        return cb(err);
-      }
+    const stream = await getDownloadStream(from);
+    const installerFile = getTempFileName('installer.msi');
 
-      const installerFile = getTempFileName('installer.msi');
-      const msiWriteStream = fs
-        .createWriteStream(installerFile)
-        .once('error', cb.bind(null, new Error('Could not write to ' + to)));
+    await new Promise((resolve, reject) => {
+      const msiWriteStream = fs.createWriteStream(installerFile).once('error', reject);
       stream.pipe(msiWriteStream);
 
-      msiWriteStream.once('finish', runInstaller.bind(null, installerFile, from, to, cb));
+      msiWriteStream.once('finish', resolve);
     });
+
+    return runInstaller(installerFile, from, to);
   }
 
-  function installChromeDr(opts, cb) {
-    installZippedFile(opts.from, opts.to, cb);
+  function installChromeDr(opts) {
+    return installZippedFile(opts.from, opts.to);
   }
 
-  function installIeDr(opts, cb) {
-    installZippedFile(opts.from, opts.to, cb);
+  function installIeDr(opts) {
+    return installZippedFile(opts.from, opts.to);
   }
 
-  function installFirefoxDr(opts, cb) {
+  function installFirefoxDr(opts) {
     // only windows build is a zip
     if (path.extname(opts.from) === '.zip') {
-      installZippedFile(opts.from, opts.to, cb);
-    } else {
-      installGzippedFile(opts.from, opts.to, cb);
+      return installZippedFile(opts.from, opts.to);
     }
+    return installGzippedFile(opts.from, opts.to);
   }
 
-  function installChromiumEdgeDr(opts, cb) {
-    installZippedFile(opts.from, opts.to, cb);
+  function installChromiumEdgeDr(opts) {
+    return installZippedFile(opts.from, opts.to);
   }
 
-  function installGzippedFile(from, to, cb) {
-    getDownloadStream(from, (err, stream) => {
-      if (err) {
-        return cb(err);
-      }
-      // Store downloaded compressed file
-      const gzipWriteStream = fs
-        .createWriteStream(to)
-        .once('error', cb.bind(null, new Error('Could not write to ' + to)));
+  async function installGzippedFile(from, to) {
+    const stream = await getDownloadStream(from);
+
+    // Store downloaded compressed file
+    await new Promise((resolve, reject) => {
+      const gzipWriteStream = fs.createWriteStream(to).once('error', reject);
       stream.pipe(gzipWriteStream);
 
-      gzipWriteStream.once('finish', uncompressGzippedFile.bind(null, from, to, cb));
+      gzipWriteStream.once('finish', resolve);
     });
+
+    return uncompressGzippedFile(from, to);
   }
 
-  function installZippedFile(from, to, cb) {
-    getDownloadStream(from, (err, stream) => {
-      if (err) {
-        return cb(err);
-      }
+  async function installZippedFile(from, to) {
+    const stream = await getDownloadStream(from);
 
+    await new Promise((resolve, reject) => {
       // Store downloaded compressed file
-      const zipWriteStream = fs
-        .createWriteStream(to)
-        .once('error', cb.bind(null, new Error('Could not write to ' + to)));
+      const zipWriteStream = fs.createWriteStream(to).once('error', reject);
       stream.pipe(zipWriteStream);
 
       // Uncompress downloaded file
-      zipWriteStream.once('finish', uncompressDownloadedFile.bind(null, to, cb));
+      zipWriteStream.once('finish', resolve);
     });
+
+    return uncompressDownloadedFile(to);
   }
 
-  function getDownloadStream(downloadUrl, cb) {
+  async function getDownloadStream(downloadUrl) {
     let prevTransferred = 0;
     const downloadStream = got.stream(downloadUrl, requestOpts);
-    downloadStream
-      .once('response', () => {
-        downloadStream.on('downloadProgress', ({ transferred, total }) => {
-          const active = isDownloadActive();
-          if (active) {
-            downloadStreams.set(downloadStream, true);
-          }
-          if (downloadStreams.get(downloadStream)) {
-            opts.progressCb(total, transferred, transferred - prevTransferred, downloadUrl, active);
-          }
-          prevTransferred = transferred;
+    return await new Promise((resolve, reject) => {
+      downloadStream
+        .once('response', () => {
+          downloadStream.on('downloadProgress', ({ transferred, total }) => {
+            const active = isDownloadActive();
+            if (active) {
+              downloadStreams.set(downloadStream, true);
+            }
+            if (downloadStreams.get(downloadStream)) {
+              opts.progressCb(total, transferred, transferred - prevTransferred, downloadUrl, active);
+            }
+            prevTransferred = transferred;
+          });
+        })
+        .once('finish', () => {
+          resolve(downloadStream);
+        })
+        .once('end', () => {
+          downloadStreams.delete(downloadStream);
+        })
+        .once('error', (err) => {
+          console.error(err);
+          reject(new Error('Could not download ' + downloadUrl));
         });
-      })
-      .once('finish', () => {
-        return cb(null, downloadStream);
-      })
-      .once('end', () => {
-        downloadStreams.delete(downloadStream);
-      })
-      .once('error', (err) => {
-        console.error(err);
-        return cb(new Error('Could not download ' + downloadUrl));
-      });
+    });
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     }
   },
   "dependencies": {
-    "async": "^3.2.0",
     "commander": "^2.20.3",
     "cross-spawn": "^7.0.3",
     "debug": "^4.3.1",
@@ -37,7 +36,7 @@
     "lodash.mapvalues": "^4.6.0",
     "lodash.merge": "^4.6.2",
     "minimist": "^1.2.5",
-    "mkdirp": "^0.5.5",
+    "mkdirp": "^1.0.4",
     "progress": "2.0.3",
     "tar-stream": "2.1.4",
     "which": "^2.0.2",

--- a/test/compute-download-urls-test.js
+++ b/test/compute-download-urls-test.js
@@ -29,8 +29,8 @@ describe('compute-download-urls', () => {
   let opts;
 
   describe('selenium-jar', () => {
-    it('basic version', () => {
-      const actual = computeDownloadUrls({
+    it('basic version', async () => {
+      const actual = await computeDownloadUrls({
         seleniumVersion: '1.0',
         seleniumBaseURL: 'https://localhost',
         drivers: {},
@@ -39,8 +39,8 @@ describe('compute-download-urls', () => {
       assert.strictEqual(actual.selenium, 'https://localhost/1.0/selenium-server-standalone-1.0.jar');
     });
 
-    it('version with patch', () => {
-      const actual = computeDownloadUrls({
+    it('version with patch', async () => {
+      const actual = await computeDownloadUrls({
         seleniumVersion: '1.0.1',
         seleniumBaseURL: 'https://localhost',
         drivers: {},
@@ -49,8 +49,8 @@ describe('compute-download-urls', () => {
       assert.strictEqual(actual.selenium, 'https://localhost/1.0/selenium-server-standalone-1.0.1.jar');
     });
 
-    it('version with beta string', () => {
-      const actual = computeDownloadUrls({
+    it('version with beta string', async () => {
+      const actual = await computeDownloadUrls({
         seleniumVersion: '3.0.0-beta2',
         seleniumBaseURL: 'https://localhost',
         drivers: {},
@@ -78,25 +78,25 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('x32 for versions < 2.34', () => {
+      it('x32 for versions < 2.34', async () => {
         opts.drivers.chrome = {
           baseURL: 'https://localhost',
           version: '2.0',
           arch: 'x32',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chrome, 'https://localhost/2.0/chromedriver_linux32.zip');
       });
 
-      it('x64', () => {
+      it('x64', async () => {
         opts.drivers.chrome = {
           baseURL: 'https://localhost',
           version: '2.0',
           arch: 'x64',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chrome, 'https://localhost/2.0/chromedriver_linux64.zip');
       });
     });
@@ -108,25 +108,25 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('Use `mac32` for versions < 2.23', () => {
+      it('Use `mac32` for versions < 2.23', async () => {
         opts.drivers.chrome = {
           baseURL: 'https://localhost',
           version: '2.22',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chrome, 'https://localhost/2.22/chromedriver_mac32.zip');
       });
 
-      it('Use `mac64` for versions >= 2.23', () => {
+      it('Use `mac64` for versions >= 2.23', async () => {
         opts.drivers.chrome = {
           baseURL: 'https://localhost',
           version: '2.23',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chrome, 'https://localhost/2.23/chromedriver_mac64.zip');
       });
     });
@@ -138,14 +138,14 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('basic version', () => {
+      it('basic version', async () => {
         opts.drivers.chrome = {
           baseURL: 'https://localhost',
           version: '2.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chrome, 'https://localhost/2.0/chromedriver_win32.zip');
       });
     });
@@ -169,85 +169,85 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('uses `wires` name for versions < 0.8.0', () => {
+      it('uses `wires` name for versions < 0.8.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.7.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.firefox, 'https://localhost/v0.7.0/wires-0.7.0-linux64.gz');
       });
 
-      it('uses `geckodriver` name for versions >= 0.8.0', () => {
+      it('uses `geckodriver` name for versions >= 0.8.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.8.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.firefox, 'https://localhost/v0.8.0/geckodriver-0.8.0-linux64.gz');
       });
 
-      it('uses correct directory for 0.3.0', () => {
+      it('uses correct directory for 0.3.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.3.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.firefox, 'https://localhost/0.3.0/wires-0.3.0-linux64.gz');
       });
 
-      it('uses leading `v` in version string when >= 0.9.0', () => {
+      it('uses leading `v` in version string when >= 0.9.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.9.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.firefox, 'https://localhost/v0.9.0/geckodriver-v0.9.0-linux64.tar.gz');
       });
 
-      it('uses plain version string when < 0.9.0', () => {
+      it('uses plain version string when < 0.9.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.7.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.firefox, 'https://localhost/v0.7.0/wires-0.7.0-linux64.gz');
       });
 
-      it('uses `.gz` file extension for versions < 0.9.0', () => {
+      it('uses `.gz` file extension for versions < 0.9.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.8.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('.gz') > 0);
         assert(actual.firefox.indexOf('.tar.gz') === -1);
       });
 
-      it('uses `.tar.gz` file extension for versions >= 0.9.0', () => {
+      it('uses `.tar.gz` file extension for versions >= 0.9.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.9.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('.tar.gz') > 0);
       });
 
-      it('throws if asking a < 0.11.0 version and an arch which is not x64', () => {
+      it('throws if asking a < 0.11.0 version and an arch which is not x64', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.9.0',
@@ -255,7 +255,7 @@ describe('compute-download-urls', () => {
         };
 
         try {
-          computeDownloadUrls(opts);
+          await computeDownloadUrls(opts);
           throw new Error('Error not thrown');
         } catch (err) {
           if (err && err.message === 'Only x64 architecture is available for Firefox < 0.11.0') {
@@ -265,36 +265,36 @@ describe('compute-download-urls', () => {
         }
       });
 
-      it('gets the right arch when arch is x86', () => {
+      it('gets the right arch when arch is x86', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.11.0',
           arch: 'x86',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('-linux32.tar.gz') > 0);
       });
 
-      it('gets the right arch when arch is x64', () => {
+      it('gets the right arch when arch is x64', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.11.0',
           arch: 'x64',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('-linux64.tar.gz') > 0);
       });
 
-      it('gets the right arch when arch is x32', () => {
+      it('gets the right arch when arch is x32', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.11.0',
           arch: 'x32',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('-linux32.tar.gz') > 0);
       });
     });
@@ -306,48 +306,48 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('uses `OSX` platform for versions < 0.9.0', () => {
+      it('uses `OSX` platform for versions < 0.9.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.8.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('OSX') > 0);
       });
 
-      it('uses `mac` platform for versions == 0.9.0', () => {
+      it('uses `mac` platform for versions == 0.9.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.9.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('mac') > 0);
         assert(actual.firefox.indexOf('macos') === -1);
       });
 
-      it('uses `macos` platform for versions >= 0.10.0', () => {
+      it('uses `macos` platform for versions >= 0.10.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.10.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('macos') > 0);
       });
 
-      it('uses `osx` platform for versions <= 0.6.0', () => {
+      it('uses `osx` platform for versions <= 0.6.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.5.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('osx') > 0);
       });
     });
@@ -359,51 +359,51 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('uses leading `v` in version string when == 0.5.0', () => {
+      it('uses leading `v` in version string when == 0.5.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.5.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.firefox, 'https://localhost/v0.5.0/wires-v0.5.0-win.zip');
       });
 
-      it('gets the right arch when arch is x32 and version >= 0.11.0', () => {
+      it('gets the right arch when arch is x32 and version >= 0.11.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.11.1',
           arch: 'x32',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('win32.zip') >= 0);
       });
 
-      it('gets the right arch when arch is x64 and version >= 0.11.0', () => {
+      it('gets the right arch when arch is x64 and version >= 0.11.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.11.0',
           arch: 'x64',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('win64.zip') >= 0);
       });
 
-      it('gets the 32 bits version when no arch specified version >= 0.11.0', () => {
+      it('gets the 32 bits version when no arch specified version >= 0.11.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.11.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('win32.zip') >= 0);
       });
 
-      it('throws if asking the 32bit version for 0.9.0/0.10.0', () => {
+      it('throws if asking the 32bit version for 0.9.0/0.10.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.10.0',
@@ -411,7 +411,7 @@ describe('compute-download-urls', () => {
         };
 
         try {
-          computeDownloadUrls(opts);
+          await computeDownloadUrls(opts);
           throw new Error('Error not thrown');
         } catch (err) {
           if (err && err.message === 'Only x64 architecture is available for Firefox 0.9.0 and 0.10.0') {
@@ -421,7 +421,7 @@ describe('compute-download-urls', () => {
         }
       });
 
-      it('throws if asking the 64bit version for < 0.9.0', () => {
+      it('throws if asking the 64bit version for < 0.9.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.8.0',
@@ -429,7 +429,7 @@ describe('compute-download-urls', () => {
         };
 
         try {
-          computeDownloadUrls(opts);
+          await computeDownloadUrls(opts);
           throw new Error('Error not thrown');
         } catch (err) {
           if (err && err.message === 'Only 32 bits architectures are available for Firefox <= 0.8.0') {
@@ -439,36 +439,36 @@ describe('compute-download-urls', () => {
         }
       });
 
-      it('uses `win32` name for versions 0.8.0 & 0.7.1', () => {
+      it('uses `win32` name for versions 0.8.0 & 0.7.1', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.7.1',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('-win32.zip') > 0);
       });
 
-      it('uses `windows` name for version 0.3.0', () => {
+      it('uses `windows` name for version 0.3.0', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.3.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('-windows.zip') > 0);
       });
 
-      it('uses `win` name for versions other versions', () => {
+      it('uses `win` name for versions other versions', async () => {
         opts.drivers.firefox = {
           baseURL: 'https://localhost',
           version: '0.5.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.firefox.indexOf('-win.zip') > 0);
       });
     });
@@ -491,36 +491,36 @@ describe('compute-download-urls', () => {
       };
     });
 
-    it('uses `Win32` platform when arch == ia32', () => {
+    it('uses `Win32` platform when arch == ia32', async () => {
       opts.drivers.ie = {
         baseURL: 'https://localhost',
         version: '2.20.0',
         arch: 'ia32',
       };
 
-      const actual = computeDownloadUrls(opts);
+      const actual = await computeDownloadUrls(opts);
       assert(actual.ie.indexOf('IEDriverServer_Win32') > 0);
     });
 
-    it('uses `x64` platform when arch == x64', () => {
+    it('uses `x64` platform when arch == x64', async () => {
       opts.drivers.ie = {
         baseURL: 'https://localhost',
         version: '2.20.0',
         arch: 'x64',
       };
 
-      const actual = computeDownloadUrls(opts);
+      const actual = await computeDownloadUrls(opts);
       assert(actual.ie.indexOf('IEDriverServer_x64') > 0);
     });
 
-    it('uses `major.minor` folder for `major.minor.patch` version', () => {
+    it('uses `major.minor` folder for `major.minor.patch` version', async () => {
       opts.drivers.ie = {
         baseURL: 'https://localhost',
         version: '2.20.1',
         arch: 'x64',
       };
 
-      const actual = computeDownloadUrls(opts);
+      const actual = await computeDownloadUrls(opts);
       assert(actual.ie.indexOf('/2.20/') > 0);
       assert(actual.ie.indexOf('2.20.1.zip') > 0);
     });
@@ -546,31 +546,27 @@ describe('compute-download-urls', () => {
     const releases = require('../lib/microsoft-edge-releases');
 
     Object.keys(releases).forEach((version) => {
-      it('uses version `' + version + '` correct url', () => {
+      it('uses version `' + version + '` correct url', async () => {
         opts.drivers.edge = { version: version };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.edge, releases[version].url);
       });
     });
 
     Object.keys(releases).forEach((version) => {
-      it('uses version `' + version + '` correct extension', () => {
+      it('uses version `' + version + '` correct extension', async () => {
         opts.drivers.edge = { version: version };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert(actual.edge.indexOf(releases[version].extension) > 0);
       });
     });
 
-    it('throws for unknown releases', () => {
-      ['1.0', '2.3', '10'].forEach((version) => {
-        opts.drivers.edge = { version: version };
+    it('throws for unknown releases', (done) => {
+      opts.drivers.edge = { version: '10' };
 
-        assert.throws(() => {
-          computeDownloadUrls(opts);
-        });
-      });
+      computeDownloadUrls(opts).catch(() => done());
     });
   });
 
@@ -592,24 +588,24 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('throws for x32 arch', () => {
+      it('throws for x32 arch', (done) => {
         opts.drivers.chromiumedge = {
           baseURL: 'https://localhost',
           version: '86.0.600.0',
           arch: 'x32',
         };
 
-        assert.throws(() => computeDownloadUrls(opts), 'Only x64 is supported for linux');
+        computeDownloadUrls(opts).catch(() => done());
       });
 
-      it('x64', () => {
+      it('x64', async () => {
         opts.drivers.chromiumedge = {
           baseURL: 'https://localhost',
           version: '86.0.600.0',
           arch: 'x64',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_linux64.zip');
       });
     });
@@ -621,24 +617,24 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('throws for x32 arch', () => {
+      it('throws for x32 arch', (done) => {
         opts.drivers.chromiumedge = {
           baseURL: 'https://localhost',
           version: '86.0.600.0',
           arch: 'x32',
         };
 
-        assert.throws(() => computeDownloadUrls(opts), 'Only x64 is supported for mac');
+        computeDownloadUrls(opts).catch(() => done());
       });
 
-      it('x64', () => {
+      it('x64', async () => {
         opts.drivers.chromiumedge = {
           baseURL: 'https://localhost',
           version: '86.0.600.0',
           arch: 'x64',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_mac64.zip');
       });
     });
@@ -650,25 +646,25 @@ describe('compute-download-urls', () => {
         });
       });
 
-      it('x32', () => {
+      it('x32', async () => {
         opts.drivers.chromiumedge = {
           baseURL: 'https://localhost',
           version: '86.0.600.0',
           arch: 'x32',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_win32.zip');
       });
 
-      it('x64', () => {
+      it('x64', async () => {
         opts.drivers.chromiumedge = {
           baseURL: 'https://localhost',
           version: '86.0.600.0',
           arch: '',
         };
 
-        const actual = computeDownloadUrls(opts);
+        const actual = await computeDownloadUrls(opts);
         assert.strictEqual(actual.chromiumedge, 'https://localhost/86.0.600.0/edgedriver_win64.zip');
       });
     });

--- a/test/no-files.js
+++ b/test/no-files.js
@@ -1,15 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
 describe('when files are missing', () => {
+  const from = path.join(__dirname, '..', '.selenium');
+  const to = path.join(__dirname, '..', '.selenium-tmp');
+
   it('should fail', (done) => {
-    const fs = require('fs');
-    const path = require('path');
-    const from = path.join(__dirname, '..', '.selenium');
-    const to = path.join(__dirname, '..', '.selenium-tmp');
-
-    fs.renameSync(from, to);
-
     const selenium = require('../');
     selenium.start((err) => {
-      fs.renameSync(to, from);
       if (err) {
         done();
         return;
@@ -17,5 +15,12 @@ describe('when files are missing', () => {
 
       done(new Error('We should have got an error'));
     });
+  });
+
+  before(() => {
+    fs.renameSync(from, to);
+  });
+  after(() => {
+    fs.renameSync(to, from);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,11 +227,6 @@ astral-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
-async@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
-
 atoa@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/atoa/-/atoa-1.0.0.tgz#0cc0e91a480e738f923ebc103676471779b34a49"
@@ -1768,12 +1763,17 @@ mkdirp@0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^0.5.1, mkdirp@^0.5.5:
+mkdirp@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@6.2.3:
   version "6.2.3"


### PR DESCRIPTION
support `latest` as Chrome, Firefox, and ChromiumEdge version and set it as default one.

Additionally, had to remove `async` package.

#468 #502 #511