### PR TITLE
update chromiumedge default URL

### DIFF
--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -27,7 +27,7 @@ module.exports = () => {
         version: 'latest',
         fallbackVersion: '87.0.637.0',
         arch: process.arch,
-        baseURL: 'https://msedgedriver.azureedge.net',
+        baseURL: 'https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver',
       },
     },
   };


### PR DESCRIPTION
The base URL for Microsoft's Edge Chrome driver appears to have been changed by Microsoft. This fix simply updates that URL.

To verify, the new list of edge driver files is viewable at: https://msedgedriver.azureedge.net/

