### PR TITLE
Fix "chromium" typo

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -300,7 +300,7 @@ function getChromiumEdgeDriverArchitecture(wantedArchitecture) {
 function getLinuxChromiumEdgeDriverArchitecture(wantedArchitecture) {
   // chromium edge supports linux 64 only
   if (wantedArchitecture !== 'x64') {
-    throw new Error('Only x64 architecture is available for chroimum edge driver for linux');
+    throw new Error('Only x64 architecture is available for chromium edge driver for linux');
   }
 
   return 'linux64';
@@ -309,7 +309,7 @@ function getLinuxChromiumEdgeDriverArchitecture(wantedArchitecture) {
 function getMacChromiumEdgeDriverArchitecture(wantedArchitecture) {
   // chromium edge supports mac 64 only
   if (wantedArchitecture !== 'x64') {
-    throw new Error('Only x64 architecture is available for chroimum edge driver for mac');
+    throw new Error('Only x64 architecture is available for chromium edge driver for mac');
   }
 
   return 'mac64';


### PR DESCRIPTION
There is a typo in following error message
```
Only x64 architecture is available for chroimum edge driver for linux
```