### PR TITLE
Update Edge WebDriver download URL

### DIFF
--- a/lib/compute-download-urls.js
+++ b/lib/compute-download-urls.js
@@ -177,7 +177,7 @@ async function computeDownloadUrls(options) {
     downloadUrls.edge = opts.drivers.edge.fullURL || getEdgeDriverUrl(opts.drivers.edge.version);
   }
   if (opts.drivers.chromiumedge) {
-    await resolveLatestVersion(opts, 'chromiumedge', 'https://msedgedriver.azureedge.net/LATEST_STABLE');
+    await resolveLatestVersion(opts, 'chromiumedge', 'https://msedgedriver.microsoft.com/LATEST_STABLE');
     downloadUrls.chromiumedge =
       opts.drivers.chromiumedge.fullURL ||
       util.format(

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -24,7 +24,7 @@ module.exports = () => {
         fallbackVersion: '117.0.2045.55',
         arch: process.arch,
         onlyDriverArgs: [],
-        baseURL: 'https://msedgedriver.azureedge.net',
+        baseURL: 'https://msedgedriver.microsoft.com',
       },
     },
   };


### PR DESCRIPTION
Looks like Microsoft updated the Edge WebDriver URL today and took out the previous CDN URL. The [official page](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver?form=MA13LH) also uses the microsoft.com URL rather than the azureedge.net one.

```
❯ nslookup msedgedriver.azureedge.net
Server:		1.1.1.1
Address:	1.1.1.1#53

** server can't find msedgedriver.azureedge.net: NXDOMAIN
```

Tested running `./bin/selenium-standalone install` on these changes and it worked fine for me. Looks like the domain changed but the download paths are untouched.